### PR TITLE
if only one children and no tag use Text instead of View

### DIFF
--- a/HTMLElement.js
+++ b/HTMLElement.js
@@ -64,6 +64,9 @@ class HTMLElement extends PureComponent {
         ].concat(Array.from(HTMLStyles.blockElements)).join('\n'))
         return Text
       } else {
+        if (this.props.children.length === 1 && !this.props.children[0].props.tagName) {
+          return Text
+        }
         return View
       }
     } else {


### PR DESCRIPTION
`<div style="font-size: 12px">text</div>`  should generate `<Text style={{ fontSize: 12 }}>text</Text>` instead of `<View style={{ fontSize: 12 }}><Text>text</Text></View>` 