### PR TITLE
v3.2.0

### DIFF
--- a/Demo/src/snippets.js
+++ b/Demo/src/snippets.js
@@ -174,7 +174,8 @@ function blueCircleRenderer (htmlAttribs, children, convertedCSSStyles, passProp
         tagName: 'bluecircle',
         htmlAttribs,
         passProps,
-        styleSet: 'VIEW'
+        styleSet: 'VIEW',
+        baseFontSize: 14,
     });
     return (
         <View

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Prop | Description | Type | Required/Default
 `classesStyles` | Provide your styles for specific HTML classes, see [styling](#styling) | `object` | Optional
 `containerStyle` | Custom style for the container of the renderered HTML | `object` | Optional
 `emSize` | The default value in pixels for `1em` | `number` | `14`
+`baseFontSize` | The default fontSize applied to `<Text>` components | `number` | `14`
 `ignoredTags` | HTML tags you don't want rendered, see [ignoring HTML content](#ignoring-html-content) | `array` | Optional, `['head', 'scripts']`
 `ignoredStyles` | CSS styles from the `style` attribute you don't want rendered, see [ignoring HTML content](#ignoring-html-content) | `array` | Optional
 `ignoreNodesFunction` | Return true in this custom function to ignore nodes very precisely, see [ignoring HTML content](#ignoring-html-content) | `function` | Optional

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-render-html",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "Archriss",
   "license": "BSD-2-Clause",
   "repository": "https://github.com/archriss/react-native-render-html",

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -50,18 +50,24 @@ export default class HTML extends PureComponent {
     componentWillMount () {
         this.registerIgnoredTags();
         this.registerDOM();
+        this.generateDefaultStyles();
     }
 
     componentWillReceiveProps (nextProps) {
-        if (this.props.html !== nextProps.html || this.props.uri !== nextProps.uri) {
+        const { html, uri, ignoredTags, renderers, baseFontSize } = this.props;
+
+        if (html !== nextProps.html || uri !== nextProps.uri) {
             this.imgsToRender = [];
             this.registerDOM(nextProps);
         }
-        if (this.props.ignoredTags !== nextProps.ignoredTags) {
+        if (ignoredTags !== nextProps.ignoredTags) {
             this.registerIgnoredTags(nextProps);
         }
-        if (this.props.renderers !== nextProps.renderers) {
+        if (renderers !== nextProps.renderers) {
             this.renderers = { ...HTMLRenderers, ...(nextProps.renderers || {}) };
+        }
+        if (baseFontSize !== nextProps.baseFontSize) {
+            this.generateDefaultStyles(nextProps.baseFontSize);
         }
     }
 
@@ -82,6 +88,11 @@ export default class HTML extends PureComponent {
         } else {
             console.warn('react-native-render-html', 'Please provide the html or uri prop.');
         }
+    }
+
+    generateDefaultStyles (baseFontSize = this.props.baseFontSize) {
+        this.defaultBlockStyles = generateDefaultBlockStyles(baseFontSize);
+        this.defaultTextStyles = generateDefaultTextStyles(baseFontSize);
     }
 
     registerIgnoredTags (props = this.props) {
@@ -278,10 +289,8 @@ export default class HTML extends PureComponent {
             const textElement = data ? <Text style={{fontSize: baseFontSize}}>{ data }</Text> : false;
 
             const classStyles = _getElementClassStyles(attribs, classesStyles);
-            let defaultTextStyles = generateDefaultTextStyles(baseFontSize);
-            let defaultBlockStyles = generateDefaultBlockStyles(baseFontSize);
             const style = [
-                (Wrapper === Text ? defaultTextStyles : defaultBlockStyles)[tagName],
+                (Wrapper === Text ? this.defaultTextStyles : this.defaultBlockStyles)[tagName],
                 tagsStyles ? tagsStyles[tagName] : undefined,
                 convertedCSSStyles,
                 classStyles

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -278,8 +278,8 @@ export default class HTML extends PureComponent {
             const textElement = data ? <Text style={{fontSize: baseFontSize}}>{ data }</Text> : false;
 
             const classStyles = _getElementClassStyles(attribs, classesStyles);
-            let defaultTextStyles = generateDefaultTextStyles(this.props.baseFontSize);
-            let defaultBlockStyles = generateDefaultBlockStyles(this.props.baseFontSize);
+            let defaultTextStyles = generateDefaultTextStyles(baseFontSize);
+            let defaultBlockStyles = generateDefaultBlockStyles(baseFontSize);
             const style = [
                 (Wrapper === Text ? defaultTextStyles : defaultBlockStyles)[tagName],
                 tagsStyles ? tagsStyles[tagName] : undefined,

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -186,9 +186,13 @@ export default class HTML extends PureComponent {
                     // This is blank, don't render an useless additional component
                     return false;
                 }
-                // Text without tags or line breaks, this can be mapped to the Text
-                // wrapper without any modification
-                return { wrapper: 'Text', data, attribs, parent, tagName: name || 'rawtext' };
+                // Text without tags, these can be mapped to the Text wrapper
+                return {
+                    wrapper: 'Text',
+                    data: data.replace(/(\r\n|\n|\r)/gm, ''), // remove linebreaks
+                    attribs, parent,
+                    tagName: name || 'rawtext'
+                };
             }
             if (type === 'tag') {
                 if (children) {
@@ -286,7 +290,7 @@ export default class HTML extends PureComponent {
                     });
             }
 
-            const textElement = data ? <Text style={{fontSize: baseFontSize}}>{ data }</Text> : false;
+            const textElement = data ? <Text style={{ fontSize: baseFontSize }}>{ data }</Text> : false;
 
             const classStyles = _getElementClassStyles(attribs, classesStyles);
             const style = [

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { View, Text } from 'react-native';
 import { BLOCK_TAGS, TEXT_TAGS, IGNORED_TAGS, STYLESETS } from './HTMLUtils';
 import { cssStringToRNStyle, _getElementClassStyles } from './HTMLStyles';
-import { defaultBlockStyles, defaultTextStyles } from './HTMLDefaultStyles';
+import { generateDefaultBlockStyles, generateDefaultTextStyles } from './HTMLDefaultStyles';
 import htmlparser2 from 'htmlparser2';
 import * as HTMLRenderers from './HTMLRenderers';
 
@@ -22,13 +22,15 @@ export default class HTML extends PureComponent {
         containerStyle: View.propTypes.style,
         onLinkPress: PropTypes.func,
         imagesMaxWidth: PropTypes.number,
-        emSize: PropTypes.number.isRequired
+        emSize: PropTypes.number.isRequired,
+        baseFontSize: PropTypes.number.isRequired
     }
 
     static defaultProps = {
         renderers: HTMLRenderers,
         decodeEntities: true,
         emSize: 14,
+        baseFontSize: 14,
         ignoredTags: IGNORED_TAGS,
         ignoredStyles: [],
         tagsStyles: {},
@@ -234,7 +236,7 @@ export default class HTML extends PureComponent {
      * @memberof HTML
      */
     renderRNElements (RNElements, parentWrapper = 'root', parentIndex = 0) {
-        const { tagsStyles, classesStyles, onLinkPress, imagesMaxWidth, emSize, ignoredStyles } = this.props;
+        const { tagsStyles, classesStyles, onLinkPress, imagesMaxWidth, emSize, ignoredStyles, baseFontSize } = this.props;
         return RNElements && RNElements.length ? RNElements.map((element, index) => {
             const { attribs, data, tagName, parentTag, children, nodeIndex, wrapper } = element;
             const Wrapper = wrapper === 'Text' ? Text : View;
@@ -267,14 +269,17 @@ export default class HTML extends PureComponent {
                         parentTag,
                         nodeIndex,
                         emSize,
+                        baseFontSize,
                         key,
                         rawChildren: children
                     });
             }
 
-            const textElement = data ? <Text>{ data }</Text> : false;
+            const textElement = data ? <Text style={{fontSize: baseFontSize}}>{ data }</Text> : false;
 
             const classStyles = _getElementClassStyles(attribs, classesStyles);
+            let defaultTextStyles = generateDefaultTextStyles(this.props.baseFontSize);
+            let defaultBlockStyles = generateDefaultBlockStyles(this.props.baseFontSize);
             const style = [
                 (Wrapper === Text ? defaultTextStyles : defaultBlockStyles)[tagName],
                 tagsStyles ? tagsStyles[tagName] : undefined,

--- a/src/HTMLDefaultStyles.js
+++ b/src/HTMLDefaultStyles.js
@@ -2,64 +2,64 @@ import { StyleSheet } from 'react-native';
 
 const BASE_FONT_SIZE = 14;
 
-export function generateDefaultBlockStyles(baseFontSize = BASE_FONT_SIZE) {
-  return StyleSheet.create({
-    div: { },
-    ul: {
-        paddingLeft: 40,
-        marginBottom: baseFontSize
-    },
-    ol: {
-        paddingLeft: 40,
-        marginBottom: baseFontSize
-    },
-    iframe: {
-        width: 200,
-        height: 200
-    },
-    hr: {
-        marginTop: baseFontSize / 2,
-        marginBottom: baseFontSize / 2,
-        height: 1,
-        backgroundColor: '#CCC'
-    },
-    p: {
-        marginTop: baseFontSize,
-        marginBottom: baseFontSize
-    }
-  });
+export function generateDefaultBlockStyles (baseFontSize = BASE_FONT_SIZE) {
+    return StyleSheet.create({
+        div: { },
+        ul: {
+            paddingLeft: 40,
+            marginBottom: baseFontSize
+        },
+        ol: {
+            paddingLeft: 40,
+            marginBottom: baseFontSize
+        },
+        iframe: {
+            width: 200,
+            height: 200
+        },
+        hr: {
+            marginTop: baseFontSize / 2,
+            marginBottom: baseFontSize / 2,
+            height: 1,
+            backgroundColor: '#CCC'
+        }
+    });
 }
 
-export function generateDefaultTextStyles(baseFontSize = BASE_FONT_SIZE) {
-  return StyleSheet.create({
-    u: { textDecorationLine: 'underline' },
-    em: { fontStyle: 'italic' },
-    i: { fontStyle: 'italic' },
-    b: { fontWeight: 'bold' },
-    strong: { fontWeight: 'bold' },
-    big: { fontSize: baseFontSize * 1.2 },
-    small: { fontSize: baseFontSize * 0.8 },
-    a: {
-        textDecorationLine: 'underline',
-        color: '#245dc1'
-    },
-    h1: _generateHeadingStyle(baseFontSize, 2, 0.67),
-    h2: _generateHeadingStyle(baseFontSize, 1.5, 0.83),
-    h3: _generateHeadingStyle(baseFontSize, 1.17, 1),
-    h4: _generateHeadingStyle(baseFontSize, 1, 1.33),
-    h5: _generateHeadingStyle(baseFontSize, 0.83, 1.67),
-    h6: _generateHeadingStyle(baseFontSize, 0.67, 2.33),
-    sub: {
-        textAlignVertical: 'top',
-        fontSize: baseFontSize * 0.8,
-        marginTop: baseFontSize / 2
-    },
-    sup: {
-        textAlignVertical: 'top',
-        fontSize: baseFontSize * 0.8,
-        marginBottom: baseFontSize / 2
-    }
-  });
+export function generateDefaultTextStyles (baseFontSize = BASE_FONT_SIZE) {
+    return StyleSheet.create({
+        u: { textDecorationLine: 'underline' },
+        em: { fontStyle: 'italic' },
+        i: { fontStyle: 'italic' },
+        b: { fontWeight: 'bold' },
+        strong: { fontWeight: 'bold' },
+        big: { fontSize: baseFontSize * 1.2 },
+        small: { fontSize: baseFontSize * 0.8 },
+        a: {
+            textDecorationLine: 'underline',
+            color: '#245dc1'
+        },
+        h1: _generateHeadingStyle(baseFontSize, 2, 0.67),
+        h2: _generateHeadingStyle(baseFontSize, 1.5, 0.83),
+        h3: _generateHeadingStyle(baseFontSize, 1.17, 1),
+        h4: _generateHeadingStyle(baseFontSize, 1, 1.33),
+        h5: _generateHeadingStyle(baseFontSize, 0.83, 1.67),
+        h6: _generateHeadingStyle(baseFontSize, 0.67, 2.33),
+        sub: {
+            textAlignVertical: 'top',
+            fontSize: baseFontSize * 0.8,
+            marginTop: baseFontSize / 2
+        },
+        sup: {
+            textAlignVertical: 'top',
+            fontSize: baseFontSize * 0.8,
+            marginBottom: baseFontSize / 2
+        },
+        p: {
+            marginTop: baseFontSize,
+            marginBottom: baseFontSize
+        }
+    });
 }
 
 /**

--- a/src/HTMLDefaultStyles.js
+++ b/src/HTMLDefaultStyles.js
@@ -2,62 +2,65 @@ import { StyleSheet } from 'react-native';
 
 const BASE_FONT_SIZE = 14;
 
-export const defaultBlockStyles = StyleSheet.create({
+export function generateDefaultBlockStyles(baseFontSize = BASE_FONT_SIZE) {
+  return StyleSheet.create({
     div: { },
     ul: {
         paddingLeft: 40,
-        marginBottom: BASE_FONT_SIZE
+        marginBottom: baseFontSize
     },
     ol: {
         paddingLeft: 40,
-        marginBottom: BASE_FONT_SIZE
+        marginBottom: baseFontSize
     },
     iframe: {
         width: 200,
         height: 200
     },
     hr: {
-        marginTop: BASE_FONT_SIZE / 2,
-        marginBottom: BASE_FONT_SIZE / 2,
+        marginTop: baseFontSize / 2,
+        marginBottom: baseFontSize / 2,
         height: 1,
         backgroundColor: '#CCC'
-    }
-});
-
-export const defaultTextStyles = StyleSheet.create({
-    p: {
-        fontSize: BASE_FONT_SIZE,
-        marginTop: BASE_FONT_SIZE,
-        marginBottom: BASE_FONT_SIZE
     },
+    p: {
+        marginTop: baseFontSize,
+        marginBottom: baseFontSize
+    }
+  });
+}
+
+export function generateDefaultTextStyles(baseFontSize = BASE_FONT_SIZE) {
+  return StyleSheet.create({
     u: { textDecorationLine: 'underline' },
     em: { fontStyle: 'italic' },
     i: { fontStyle: 'italic' },
     b: { fontWeight: 'bold' },
     strong: { fontWeight: 'bold' },
-    big: { fontSize: BASE_FONT_SIZE * 1.2 },
-    small: { fontSize: BASE_FONT_SIZE * 0.8 },
+    big: { fontSize: baseFontSize * 1.2 },
+    small: { fontSize: baseFontSize * 0.8 },
     a: {
         textDecorationLine: 'underline',
         color: '#245dc1'
     },
-    h1: _generateHeadingStyle(BASE_FONT_SIZE, 2, 0.67),
-    h2: _generateHeadingStyle(BASE_FONT_SIZE, 1.5, 0.83),
-    h3: _generateHeadingStyle(BASE_FONT_SIZE, 1.17, 1),
-    h4: _generateHeadingStyle(BASE_FONT_SIZE, 1, 1.33),
-    h5: _generateHeadingStyle(BASE_FONT_SIZE, 0.83, 1.67),
-    h6: _generateHeadingStyle(BASE_FONT_SIZE, 0.67, 2.33),
+    h1: _generateHeadingStyle(baseFontSize, 2, 0.67),
+    h2: _generateHeadingStyle(baseFontSize, 1.5, 0.83),
+    h3: _generateHeadingStyle(baseFontSize, 1.17, 1),
+    h4: _generateHeadingStyle(baseFontSize, 1, 1.33),
+    h5: _generateHeadingStyle(baseFontSize, 0.83, 1.67),
+    h6: _generateHeadingStyle(baseFontSize, 0.67, 2.33),
     sub: {
         textAlignVertical: 'top',
-        fontSize: BASE_FONT_SIZE * 0.8,
-        marginTop: BASE_FONT_SIZE / 2
+        fontSize: baseFontSize * 0.8,
+        marginTop: baseFontSize / 2
     },
     sup: {
         textAlignVertical: 'top',
-        fontSize: BASE_FONT_SIZE * 0.8,
-        marginBottom: BASE_FONT_SIZE / 2
+        fontSize: baseFontSize * 0.8,
+        marginBottom: baseFontSize / 2
     }
-});
+  });
+}
 
 /**
 * Small utility for generating heading styles

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -48,7 +48,7 @@ export function img (htmlAttribs, children, convertedCSSStyles, passProps = {}) 
 }
 
 export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
-    const { rawChildren, nodeIndex, key } = passProps;
+    const { rawChildren, nodeIndex, key, baseFontSize } = passProps;
     children = children.map((child, index) => {
         const rawChild = rawChildren[index];
         let prefix = false;
@@ -57,16 +57,16 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
                 prefix = (
                     <View style={{
                         marginRight: 10,
-                        width: 5,
-                        height: 5,
-                        marginTop: 5,
-                        borderRadius: 2.5,
+                        width: baseFontSize / 2.8,
+                        height: baseFontSize / 2.8,
+                        marginTop: baseFontSize / 2,
+                        borderRadius: baseFontSize / 2.8,
                         backgroundColor: 'black'
                     }} />
                 );
             } else if (rawChild.parentTag === 'ol') {
                 prefix = (
-                    <Text style={{ marginRight: 5 }}>{ index + 1 })</Text>
+                    <Text style={{ marginRight: 5, fontSize: baseFontSize }}>{ index + 1 })</Text>
                 );
             }
         }

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -108,7 +108,7 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
 
 export function br (htlmAttribs, children, convertedCSSStyles, passProps) {
     return (
-        <View style={{ height: 1.2 * passProps.emSize }} key={passProps.key} />
+        <Text style={{ height: 1.2 * passProps.emSize, flex: 1 }} key={passProps.key}>{"\n"}</Text>
     );
 }
 

--- a/src/HTMLStyles.js
+++ b/src/HTMLStyles.js
@@ -28,8 +28,8 @@ function cssStringToObject (str) {
  * @returns {object}
  */
 export function _constructStyles ({ tagName, htmlAttribs, passProps, additionalStyles, styleSet = 'VIEW', baseFontSize }) {
-    let defaultTextStyles = generateDefaultTextStyles(this.props.baseFontSize);
-    let defaultBlockStyles = generateDefaultBlockStyles(this.props.baseFontSize);
+    let defaultTextStyles = generateDefaultTextStyles(baseFontSize);
+    let defaultBlockStyles = generateDefaultBlockStyles(baseFontSize);
     return [
         (styleSet === 'VIEW' ? defaultBlockStyles : defaultTextStyles)[tagName],
         passProps.htmlStyles ? passProps.htmlStyles[tagName] : undefined,

--- a/src/HTMLStyles.js
+++ b/src/HTMLStyles.js
@@ -1,5 +1,5 @@
 import { PERC_SUPPORTED_STYLES, STYLESETS, stylePropTypes } from './HTMLUtils';
-import { defaultBlockStyles, defaultTextStyles } from './HTMLDefaultStyles';
+import { generateDefaultBlockStyles, generateDefaultTextStyles } from './HTMLDefaultStyles';
 import checkPropTypes from './checkPropTypes';
 
 /**
@@ -27,7 +27,9 @@ function cssStringToObject (str) {
  * @param {any} { tagName, htmlAttribs, passProps, additionalStyles, styleSet = 'VIEW' }
  * @returns {object}
  */
-export function _constructStyles ({ tagName, htmlAttribs, passProps, additionalStyles, styleSet = 'VIEW' }) {
+export function _constructStyles ({ tagName, htmlAttribs, passProps, additionalStyles, styleSet = 'VIEW', baseFontSize }) {
+    let defaultTextStyles = generateDefaultTextStyles(this.props.baseFontSize);
+    let defaultBlockStyles = generateDefaultBlockStyles(this.props.baseFontSize);
     return [
         (styleSet === 'VIEW' ? defaultBlockStyles : defaultTextStyles)[tagName],
         passProps.htmlStyles ? passProps.htmlStyles[tagName] : undefined,

--- a/src/HTMLUtils.js
+++ b/src/HTMLUtils.js
@@ -3,12 +3,12 @@ import _RNViewStylePropTypes from 'react-native/Libraries/Components/View/ViewSt
 import _RNImageStylePropTypes from 'react-native/Libraries/Image/ImageStylePropTypes';
 
 export const BLOCK_TAGS = ['address', 'article', 'aside', 'footer', 'hgroup', 'nav', 'section', 'blockquote', 'dd', 'div',
-'dl', 'dt', 'figure', 'hr', 'li', 'main', 'ol', 'ul', 'br', 'cite', 'data', 'rp', 'rtc', 'ruby', 'area',
+'dl', 'dt', 'figure', 'hr', 'li', 'main', 'ol', 'ul', 'cite', 'data', 'rp', 'rtc', 'ruby', 'area',
 'img', 'map', 'center'];
 
 export const TEXT_TAGS = ['a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'figcaption', 'p', 'pre', 'abbr', 'b', 'bdi', 'bdo', 'code',
 'dfn', 'i', 'kbd', 'mark', 'q', 'rt', 's', 'samp', 'small', 'big', 'span', 'strong', 'sub', 'sup', 'time', 'u', 'var', 'wbr',
-'del', 'ins', 'blink', 'font', 'em', 'bold'];
+'del', 'ins', 'blink', 'font', 'em', 'bold', 'br'];
 
 export const IGNORED_TAGS = ['head', 'scripts', 'audio', 'video', 'track', 'embed', 'object', 'param', 'source', 'canvas', 'noscript',
 'caption', 'col', 'colgroup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'button', 'datalist', 'fieldset', 'form',


### PR DESCRIPTION
## New features

* Add `baseFontSize` prop so you can change the size of all your texts in a single prop without having to style every text tag (thanks @peacechen !)

## Fixes

* Texts elements that are siblings of `<br>` tags should receive the styling of their parent properly
* Line breaks in your HTML won't actually render line breaks in your native components, for instance :

```html
<p><b>Description</b><br>Some description...<br />
Item 1,
Item 2,
Item 3,
</p>
```

Item 1, 2, and 3 will be on the same line, regardless of the line breaks of the snippet.
