### PR TITLE
v3.5.0

### DIFF
--- a/Demo/package.json
+++ b/Demo/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "16.0.0-alpha.12",
     "react-native": "0.48.3",
-    "react-native-render-html": "3.4.0"
+    "react-native-render-html": "3.5.0-rc.1"
   },
   "devDependencies": {
     "babel-jest": "21.0.2",

--- a/Demo/package.json
+++ b/Demo/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "16.0.0-alpha.12",
     "react-native": "0.48.3",
-    "react-native-render-html": "3.5.0-rc.1"
+    "react-native-render-html": "3.5.0-rc.4"
   },
   "devDependencies": {
     "babel-jest": "21.0.2",

--- a/Demo/package.json
+++ b/Demo/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "16.0.0-alpha.12",
     "react-native": "0.48.3",
-    "react-native-render-html": "3.5.0-rc.4"
+    "react-native-render-html": "3.5.0"
   },
   "devDependencies": {
     "babel-jest": "21.0.2",

--- a/Demo/src/HTMLDemo.js
+++ b/Demo/src/HTMLDemo.js
@@ -11,7 +11,8 @@ const DEFAULT_PROPS = {
     htmlStyles: CUSTOM_STYLES,
     renderers: CUSTOM_RENDERERS,
     imagesMaxWidth: IMAGES_MAX_WIDTH,
-    onLinkPress: (evt, href) => { Linking.openURL(href); }
+    onLinkPress: (evt, href) => { Linking.openURL(href); },
+    debug: true
 };
 
 export default class Demo extends Component {

--- a/Demo/src/snippets.js
+++ b/Demo/src/snippets.js
@@ -3,14 +3,14 @@ import { View } from 'react-native';
 import { _constructStyles } from 'react-native-render-html/src/HTMLStyles';
 
 export const paragraphs = `
-    <p style="font-size:1.3em;">This paragraph is styled a font size set in em !</p>
-    <em>This one showcases the default renderer for the "em" HTML tag.</em>
-    <p style="padding:10%;">This one features a padding <strong>in percentage !</strong></p>
-    <hr />
-    <i>Here, we have a style set on the "i" tag with the "tagsStyles" prop.</i>
-    <p>And <a href="http://google.fr">This is a link !</a></p>
-    <a href="http://google.fr"><div style="background-color: red; height: 20px; width:40px;"></div></a>
-    <p class="last-paragraph">Finally, this paragraph is styled through the classesStyles prop</p>
+<p style="font-size:1.3em;">This paragraph is styled a font size set in em !</p>
+<em>This one showcases the default renderer for the "em" HTML tag.</em>
+<p style="padding:10%;">This one features a padding <strong>in percentage !</strong></p>
+<hr />
+<i>Here, we have a style set on the "i" tag with the "tagsStyles" prop.</i>
+<p>And <a href="http://google.fr">This is a link !</a></p>
+<a href="http://google.fr"><div style="background-color: red; height: 20px; width:40px;"></div></a>
+<p class="last-paragraph">Finally, this paragraph is styled through the classesStyles prop</p>
 `;
 
 export const lists = `
@@ -76,6 +76,31 @@ export const layoutStyles = `
         <p style="color:white">Text inside a rectangle with a 20% padding</p>
     </div>
 `;
+
+export const textsStylesBehaviour = `
+<p>Styling texts is a very tricky part of converting HTML into react-native components.</p>
+<p>The way react-native's <em>Text</em> components behaves is a lot different from our browsers' implementation.</p>
+<p>Let's see how styles are applied to texts with this plugin.</p>
+
+<div style="color:red;">This text is inside a div, without a text tag wrapping it. The <em>div</em> tag only has <em>color:red;</em> as style.</div>
+
+In the example above, you may find, if you inspect the rendered components, that it's the <em>Text</em> component inside that actually receives the color attribute.
+This is because this library parses every text-only style of <em>View</em> wrappers and moves them to each <em>Text</em> child.
+
+<div style="color:red">
+    <p>This first paragraph doesn't have a specific styling.</p>
+    <p style="color:blue;">This one is blue.</p>
+</div>
+
+<p>Here, the <em>div</em> wrapper still has <em>color:red;</em> as style.</div>.</p>
+
+<p>The first paragraph inside it doesn't have any style attribute, either from HTML or from the <em>tagsStyles</em> or <em>classesStyles</em> props.</p>
+<p>The second one is set to be blue from its <em>style</em> attribute.</p>
+
+<p>You can see the order of priorities that applies to styling. The less important are your <em>tagsStyles</em>, 
+then your <em>classessStyles</em> and finally the styles parsed from your HTML content.</p>
+`;
+
 
 export const ignoringTagsAndStyles = `
     <p>The following tag (h2) is ignored with the "ignoredTags" prop</p>
@@ -155,6 +180,14 @@ export default {
     images404: { name: '404 images', props: { baseFontSize: 20 } },
     trickyStuff: { name: 'Tricky stuff' },
     layoutStyles: { name: 'Layout styles' },
+    textsStylesBehaviour: {
+        name: 'Texts styles behaviour',
+        props: {
+            tagsStyles: {
+                div: { borderWidth: 1, padding: 10, marginBottom: 10 }
+            }
+        }
+    },
     ignoringTagsAndStyles: {
         name: 'Ignoring tags & styles',
         props: {

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Prop | Description | Type | Required/Default
 `uri` | *(experimental)* remote website to parse and render | `string` | Optional
 `decodeEntities` | Decode HTML entities of your content | `bool` | Optional, defaults to `true`
 `imagesMaxWidth` | Resize your images to this maximum width, see [images](#images) | `number` | Optional
+`imagesInitialDimensions` | Default width and height to display while image's dimensions are being retrieved, see [images](#images) | `{ width: 100, height: 100 }` | Optional
 `onLinkPress` | Fired with the event and the href as its arguments when tapping a link | `function` | Optional
 `onParsed` | Fired when your HTML content has been parsed, 1st arg is `dom` from htmlparser2, 2nd is `RNElements` from this module | `function` | Optional
 `tagsStyles` | Provide your styles for specific HTML tags, see [styling](#styling) | `object` | Optional
@@ -154,7 +155,7 @@ Here's an usage example
 
 const html = `
     <i>Here, we have a style set on the "i" tag with the "tagsStyles" prop.</i>
-    <p class="last-paragraph">Finally, this paragraph is style through the classesStyles prop</p>`;
+    <p class="last-paragraph">Finally, this paragraph is styled through the classesStyles prop</p>`;
 ```
 
 ![](https://puu.sh/xF7Jx/e4b395975d.png)
@@ -168,6 +169,8 @@ If you can't set the dimension of each image in your content, you might find the
 A nice trick, demonstrated in the [basic usage of this module](#basic-usage) is to use the `Dimensions` API of react-native : `imagesMaxWidth={Dimensions.get('window').width}`. You could substract a value to it to make a margin.
 
 Please note that if you set width AND height through any mean of styling, `imagesMaxWidth` will be ignored.
+
+Before their dimensions have been properly retrieved, images will temporarily be rendered in 100px wide squares. You can override this default value with prop `imagesInitialDimensions`.
 
 Images with broken links will render an empty square with a thin border, similar to what safari renders in a webview.
 
@@ -228,7 +231,7 @@ You can't expect native components to be able to render *everything* you can fin
 * `ignoredStyles` : array of ignored CSS rules. Nothing is ignored by default
 * `ignoreNodesFunction` : this is a cumbersome, yet powerful, way of ignoring very specific stuff.
 
-**Please note** that if you supply `ignoredTags`, you will override the default ignored ones. There are *a lot* of them, if you want to keep them and add you own, you can do something like : 
+**Please note** that if you supply `ignoredTags`, you will override the default ignored ones. There are *a lot* of them, if you want to keep them and add you own, you can do something like :
 
 ```javascript
 import { IGNORED_TAGS } from 'react-native-render-html/HTMLUtils';

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Prop | Description | Type | Required/Default
 `listsPrefixesRenderers` | Your custom renderers from `ul` and `ol` bullets, see [lists prefixes](#lists-prefixes) | `object` | Optional
 `containerStyle` | Custom style for the default container of the renderered HTML | `object` | Optional
 `customWrapper` | Replace the default wrapper with a function that takes your content as the first parameter | `function` | Optional
+`remoteLoadingView` | Replace the default loader while fetching a remote website's content | `function` | Optional
+`remoteErrorView` | Replace the default error if a remote website's content could not be fetched | `function` | Optional
 `emSize` | The default value in pixels for `1em` | `number` | `14`
 `baseFontStyle` | The default style applied to `<Text>` components | `number` | `14`
 `alterData` | Target some specific texts and change their content, see [altering content](#altering-content) | `function` | Optional

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ An iOS/Android pure javascript react-native component that renders your HTML int
     - [Props](#props)
     - [Demo](#demo)
     - [Creating custom renderers](#creating-custom-renderers)
+        - [Custom HTML tags](#custom-html-tags)
+        - [Lists prefixes](#lists-prefixes)
     - [Styling](#styling)
     - [Images](#images)
     - [Altering content](#altering-content)
@@ -61,17 +63,20 @@ Prop | Description | Type | Required/Default
 `decodeEntities` | Decode HTML entities of your content | `bool` | Optional, defaults to `true`
 `imagesMaxWidth` | Resize your images to this maximum width, see [images](#images) | `number` | Optional
 `onLinkPress` | Fired with the event and the href as its arguments when tapping a link | `function` | Optional
+`onParsed` | Fired when your HTML content has been parsed, 1st arg is `dom` from htmlparser2, 2nd is `RNElements` from this module | `function` | Optional
 `tagsStyles` | Provide your styles for specific HTML tags, see [styling](#styling) | `object` | Optional
 `classesStyles` | Provide your styles for specific HTML classes, see [styling](#styling) | `object` | Optional
+`listsPrefixesRenderers` | Your custom renderers from `ul` and `ol` bullets, see [lists prefixes](#lists-prefixes) | `object` | Optional
 `containerStyle` | Custom style for the default container of the renderered HTML | `object` | Optional
 `customWrapper` | Replace the default wrapper with a function that takes your content as the first parameter | `function` | Optional
 `emSize` | The default value in pixels for `1em` | `number` | `14`
-`baseFontSize` | The default fontSize applied to `<Text>` components | `number` | `14`
+`baseFontStyle` | The default style applied to `<Text>` components | `number` | `14`
 `alterData` | Target some specific texts and change their content, see [altering content](#altering-content) | `function` | Optional
 `alterChildren` | Target some specific nested nodes and change them, see [altering content](#altering-content) | `function` | Optional
-`ignoredTags` | HTML tags you don't want rendered, see [ignoring HTML content](#ignoring-html-content) | `array` | Optional, `['head', 'scripts']`
+`ignoredTags` | HTML tags you don't want rendered, see [ignoring HTML content](#ignoring-html-content) | `array` | Optional, `['head', 'scripts', ...]`
 `ignoredStyles` | CSS styles from the `style` attribute you don't want rendered, see [ignoring HTML content](#ignoring-html-content) | `array` | Optional
 `ignoreNodesFunction` | Return true in this custom function to ignore nodes very precisely, see [ignoring HTML content](#ignoring-html-content) | `function` | Optional
+`debug` | Prints the parsing result from htmlparser2 and render-html after the initial render | `bool` | Optional, defaults to `false`
 
 ## Demo
 
@@ -84,6 +89,8 @@ Feel free to write more advanced examples and submit a pull-request for it, it w
 ## Creating custom renderers
 
 This is very useful if you want to make some very specific styling of your HTML content, or even implement custom HTML tags.
+
+### Custom HTML tags
 
 Just pass an object to the `renderers` prop with the tag name as the key, an a function as its value, like so :
 
@@ -113,6 +120,21 @@ Your renderers functions receive several arguments that will be very useful to m
 * `convertedCSSStyles` : conversion of the `style` attribute from CSS to react-native's stylesheet
 * `passProps` : various useful information : `groupInfo`, `parentTagName`, `parentIsText`...
 
+### Lists prefixes
+
+The default renderer of the `<ul>` and `<ol>` tags will either render a bullet or the count of your elements. If you wish to change this without having to re-write the whole list rendering implementation, you can use the `listsPrefixesRenderers` prop.
+
+Just like with the `renderers` prop, supply an object with `ul` and/or `ul` as functions that recevie the [same arguments as your custom HTML tags](#custom-html-tags). For instance, you can swap the default black bullet of `<ul>` with a blue cross :
+
+```javascript
+// ... your props
+ul: (htmlAttribs, children, convertedCSSStyles, passProps) => {
+    return (
+        <Text style={{ color: 'blue', fontSize: 16 }}>+</Text>
+    );
+}
+```
+
 ## Styling
 
 In addition to your custom renderers, you can apply specific styles to HTML tags (`tagsStyles`) or HTML classes (`classesStyles`). You can also combine these styles with your custom renderers.
@@ -120,6 +142,8 @@ In addition to your custom renderers, you can apply specific styles to HTML tags
 Styling options override thesmelves, so you might render a custom HTML tag with a [custom renderer](#creating-custom-renderers) like `<bluecircle>`, make it green with a class `<bluecircle class="make-me-green">` or make it red by styling the tag itself.
 
 The default style of your custom renderer will be merged to the one from your `classesStyles` which will also be merged by the `style` attribute.
+
+> **IMPORTANT NOTE : Do NOT use the `StyleSheet` API to create the styles you're going to feed to `tagsStyle` and `classesStyles`. Although it might look like it's working at first, the caching logic of `react-native` makes it impossible for this module to deep check each of your style to properly apply the precedence and priorities of your nested tags' styles.**
 
 Here's an usage example
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-render-html",
-  "version": "3.4.0",
+  "version": "3.5.0-rc.4",
   "author": "Archriss",
   "license": "BSD-2-Clause",
   "repository": "https://github.com/archriss/react-native-render-html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-render-html",
-  "version": "3.5.0-rc.4",
+  "version": "3.5.0",
   "author": "Archriss",
   "license": "BSD-2-Clause",
   "repository": "https://github.com/archriss/react-native-render-html",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "events": "^1.1.0",
     "html-entities": "^1.2.0",
     "htmlparser2": "^3.9.0",
+    "lodash.isequal": "4.5.0",
     "stream": "0.0.2"
   },
   "peerDependencies": {

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -14,6 +14,7 @@ export default class HTML extends PureComponent {
         ignoredTags: PropTypes.array.isRequired,
         ignoredStyles: PropTypes.array.isRequired,
         decodeEntities: PropTypes.bool.isRequired,
+        debug: PropTypes.bool.isRequired,
         ignoreNodesFunction: PropTypes.func,
         alterData: PropTypes.func,
         alterChildren: PropTypes.func,
@@ -31,6 +32,7 @@ export default class HTML extends PureComponent {
 
     static defaultProps = {
         renderers: HTMLRenderers,
+        debug: false,
         decodeEntities: true,
         emSize: 14,
         baseFontSize: 14,
@@ -337,7 +339,7 @@ export default class HTML extends PureComponent {
     }
 
     render () {
-        const { decodeEntities, customWrapper } = this.props;
+        const { decodeEntities, customWrapper, debug } = this.props;
         const { dom } = this.state;
         if (!dom) {
             return false;
@@ -345,10 +347,12 @@ export default class HTML extends PureComponent {
         let RNNodes;
         const parser = new htmlparser2.Parser(
             new htmlparser2.DomHandler((_err, dom) => {
-                // console.log('DOMNodes', dom);
-                // console.log('Parsed nodes', this.mapDOMNodesTORNElements(dom));
                 const RNElements = this.mapDOMNodesTORNElements(dom);
                 RNNodes = this.renderRNElements(RNElements);
+                if (debug) {
+                    console.log('DOMNodes from htmlparser2', dom);
+                    console.log('RNElements from render-html', RNElements);
+                }
             }),
             { decodeEntities: decodeEntities }
         );

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -168,7 +168,7 @@ export default class HTML extends PureComponent {
                     // Loop on its next siblings and store them in an array
                     // until we encounter a block or a <p>
                     let nextSibling = children[j];
-                    if (nextSibling.wrapper !== 'Text' || TEXT_TAGS_IGNORING_ASSOCIATION.indexOf(nextSibling.tagName) === -1) {
+                    if (nextSibling.wrapper !== 'Text' || TEXT_TAGS_IGNORING_ASSOCIATION.indexOf(nextSibling.tagName) !== -1) {
                         break;
                     }
                     wrappedTexts.push(nextSibling);

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -15,6 +15,7 @@ export default class HTML extends PureComponent {
         ignoredStyles: PropTypes.array.isRequired,
         decodeEntities: PropTypes.bool.isRequired,
         debug: PropTypes.bool.isRequired,
+        listsPrefixesRenderers: PropTypes.object,
         ignoreNodesFunction: PropTypes.func,
         alterData: PropTypes.func,
         alterChildren: PropTypes.func,
@@ -214,7 +215,8 @@ export default class HTML extends PureComponent {
                 return {
                     wrapper: 'Text',
                     data: data.replace(/(\r\n|\n|\r)/gm, ''), // remove linebreaks
-                    attribs, parent,
+                    attribs,
+                    parent,
                     tagName: name || 'rawtext'
                 };
             }
@@ -275,7 +277,10 @@ export default class HTML extends PureComponent {
      * @memberof HTML
      */
     renderRNElements (RNElements, parentWrapper = 'root', parentIndex = 0) {
-        const { tagsStyles, classesStyles, onLinkPress, imagesMaxWidth, emSize, ignoredStyles, baseFontSize } = this.props;
+        const {
+            tagsStyles, classesStyles, onLinkPress, imagesMaxWidth, emSize, ignoredStyles, baseFontSize,
+            listsPrefixesRenderers
+        } = this.props;
         return RNElements && RNElements.length ? RNElements.map((element, index) => {
             const { attribs, data, tagName, parent, parentTag, children, nodeIndex, wrapper } = element;
             const Wrapper = wrapper === 'Text' ? Text : View;
@@ -310,6 +315,7 @@ export default class HTML extends PureComponent {
                         emSize,
                         baseFontSize,
                         key,
+                        listsPrefixesRenderers,
                         rawChildren: children
                     });
             }

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -345,7 +345,7 @@ export default class HTML extends PureComponent {
                 false;
 
             const style = [
-                (Wrapper === Text ? this.defaultTextStyles : this.defaultBlockStyles)[tagName],
+                (!tagsStyles || !tagsStyles[tagName]) ? (Wrapper === Text ? this.defaultTextStyles : this.defaultBlockStyles)[tagName] : undefined,
                 classStyles,
                 tagsStyles ? tagsStyles[tagName] : undefined,
                 convertedCSSStyles

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -270,7 +270,7 @@ export default class HTML extends PureComponent {
                     // If children cannot be nested in a Text, or if the tag
                     // maps to a block element, use a view
                     return { wrapper: 'View', children, attribs, parent, tagName: name, parentTag };
-                } else if (TEXT_TAGS.indexOf(name.toLowerCase()) !== -1) {
+                } else if (TEXT_TAGS.indexOf(name.toLowerCase()) !== -1 || MIXED_TAGS.indexOf(name.toLowerCase()) !== -1) {
                     // We are able to nest its children inside a Text
                     return { wrapper: 'Text', children, attribs, parent, tagName: name, parentTag };
                 }

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -28,6 +28,10 @@ export default class HTML extends PureComponent {
         onLinkPress: PropTypes.func,
         onParsed: PropTypes.func,
         imagesMaxWidth: PropTypes.number,
+        imagesInitialDimensions: PropTypes.shape({
+            width: PropTypes.number,
+            height: PropTypes.number
+        }),
         emSize: PropTypes.number.isRequired,
         baseFontStyle: PropTypes.object.isRequired
     }
@@ -314,10 +318,7 @@ export default class HTML extends PureComponent {
      * @memberof HTML
      */
     renderRNElements (RNElements, parentWrapper = 'root', parentIndex = 0) {
-        const {
-            tagsStyles, classesStyles, onLinkPress, imagesMaxWidth, emSize, ignoredStyles, baseFontStyle,
-            listsPrefixesRenderers
-        } = this.props;
+        const { tagsStyles, classesStyles, emSize, ignoredStyles } = this.props;
         return RNElements && RNElements.length ? RNElements.map((element, index) => {
             const { attribs, data, tagName, parentTag, children, nodeIndex, wrapper } = element;
             const Wrapper = wrapper === 'Text' ? Text : View;
@@ -342,19 +343,13 @@ export default class HTML extends PureComponent {
                     childElements,
                     convertedCSSStyles,
                     {
+                        ...this.props,
                         parentWrapper: wrapper,
-                        tagsStyles,
-                        classesStyles,
-                        onLinkPress,
-                        imagesMaxWidth,
                         parentTag,
                         nodeIndex,
                         parentIndex,
-                        emSize,
-                        baseFontStyle,
                         key,
                         data,
-                        listsPrefixesRenderers,
                         rawChildren: children
                     });
             }

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -1,14 +1,13 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, ViewPropTypes } from 'react-native';
-import { BLOCK_TAGS, TEXT_TAGS, IGNORED_TAGS, STYLESETS } from './HTMLUtils';
+import { BLOCK_TAGS, TEXT_TAGS, IGNORED_TAGS, TEXT_TAGS_IGNORING_ASSOCIATION, STYLESETS } from './HTMLUtils';
 import { cssStringToRNStyle, _getElementClassStyles } from './HTMLStyles';
 import { generateDefaultBlockStyles, generateDefaultTextStyles } from './HTMLDefaultStyles';
 import htmlparser2 from 'htmlparser2';
 import * as HTMLRenderers from './HTMLRenderers';
 
 export default class HTML extends PureComponent {
-
     static propTypes = {
         renderers: PropTypes.object.isRequired,
         ignoredTags: PropTypes.array.isRequired,
@@ -144,14 +143,14 @@ export default class HTML extends PureComponent {
     associateRawTexts (children) {
         for (let i = 0; i < children.length; i++) {
             const child = children[i];
-            if ((child.wrapper === 'Text' && child.tagName !== 'p') && children.length > 1 && (!child.parent || child.parent.name !== 'p')) {
+            if ((child.wrapper === 'Text' && TEXT_TAGS_IGNORING_ASSOCIATION.indexOf(child.tagName) === -1) && children.length > 1 && (!child.parent || child.parent.name !== 'p')) {
                 // Texts outside <p> or not <p> themselves (with siblings)
                 let wrappedTexts = [];
                 for (let j = i; j < children.length; j++) {
                     // Loop on its next siblings and store them in an array
                     // until we encounter a block or a <p>
                     let nextSibling = children[j];
-                    if (nextSibling.wrapper !== 'Text' || nextSibling.tagName === 'p') {
+                    if (nextSibling.wrapper !== 'Text' || TEXT_TAGS_IGNORING_ASSOCIATION.indexOf(nextSibling.tagName) === -1) {
                         break;
                     }
                     wrappedTexts.push(nextSibling);

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -242,7 +242,7 @@ export default class HTML extends PureComponent {
             const firstChild = children && children[0];
             if (firstChild && children.length === 1) {
                 // Specific tweaks for wrappers with a single child
-                if (attribs === firstChild.attribs &&
+                if ((attribs === firstChild.attribs || !firstChild.attribs) &&
                     firstChild.wrapper === wrapper &&
                     (tagName === firstChild.tagName || firstChild.tagName === 'rawtext')) {
                     // If the only child of a node is using the same wrapper, merge them into one

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -365,8 +365,8 @@ export default class HTML extends PureComponent {
 
             const style = [
                 (!tagsStyles || !tagsStyles[tagName]) ? (Wrapper === Text ? this.defaultTextStyles : this.defaultBlockStyles)[tagName] : undefined,
-                classStyles,
                 tagsStyles ? tagsStyles[tagName] : undefined,
+                classStyles,
                 convertedCSSStyles
             ]
             .filter((s) => s !== undefined);

--- a/src/HTMLDefaultStyles.js
+++ b/src/HTMLDefaultStyles.js
@@ -27,7 +27,7 @@ export function generateDefaultBlockStyles (baseFontSize = BASE_FONT_SIZE) {
 }
 
 export function generateDefaultTextStyles (baseFontSize = BASE_FONT_SIZE) {
-    return StyleSheet.create({
+    return {
         u: { textDecorationLine: 'underline' },
         em: { fontStyle: 'italic' },
         i: { fontStyle: 'italic' },
@@ -59,7 +59,7 @@ export function generateDefaultTextStyles (baseFontSize = BASE_FONT_SIZE) {
             marginTop: baseFontSize,
             marginBottom: baseFontSize
         }
-    });
+    };
 }
 
 /**

--- a/src/HTMLDefaultStyles.js
+++ b/src/HTMLDefaultStyles.js
@@ -1,9 +1,7 @@
-import { StyleSheet } from 'react-native';
-
 const BASE_FONT_SIZE = 14;
 
 export function generateDefaultBlockStyles (baseFontSize = BASE_FONT_SIZE) {
-    return StyleSheet.create({
+    return {
         div: { },
         ul: {
             paddingLeft: 40,
@@ -14,7 +12,6 @@ export function generateDefaultBlockStyles (baseFontSize = BASE_FONT_SIZE) {
             marginBottom: baseFontSize
         },
         iframe: {
-            width: 200,
             height: 200
         },
         hr: {
@@ -23,7 +20,7 @@ export function generateDefaultBlockStyles (baseFontSize = BASE_FONT_SIZE) {
             height: 1,
             backgroundColor: '#CCC'
         }
-    });
+    };
 }
 
 export function generateDefaultTextStyles (baseFontSize = BASE_FONT_SIZE) {

--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -17,6 +17,8 @@ export default class HTMLImage extends PureComponent {
     static propTypes = {
         source: PropTypes.object.isRequired,
         alt: PropTypes.string,
+        height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         style: Image.propTypes.style,
         imagesMaxWidth: PropTypes.number
     }
@@ -29,26 +31,33 @@ export default class HTMLImage extends PureComponent {
         this.getImageSize(nextProps);
     }
 
-    getDimensionsFromStyle (style) {
-        let width;
-        let height;
+    getDimensionsFromStyle (style, height, width) {
+        let styleWidth;
+        let styleHeight;
+
+        if (height) {
+            styleHeight = height;
+        }
+        if (width) {
+            styleWidth = width;
+        }
         style.forEach((styles) => {
-            if (styles['width']) {
-                width = styles['width'];
+            if (!width && styles['width']) {
+                styleWidth = styles['width'];
             }
-            if (styles['height']) {
-                height = styles['height'];
+            if (!height && styles['height']) {
+                styleHeight = styles['height'];
             }
         });
-        return { width, height };
+        return { styleWidth, styleHeight };
     }
 
     getImageSize (props = this.props) {
-        const { source, imagesMaxWidth, style } = props;
-        const { width, height } = this.getDimensionsFromStyle(style);
+        const { source, imagesMaxWidth, style, height, width } = props;
+        const { styleWidth, styleHeight } = this.getDimensionsFromStyle(style, height, width);
 
-        if (width && height) {
-            return this.setState({ width, height });
+        if (styleWidth && styleHeight) {
+            return this.setState({ width: parseInt(styleWidth, 10), height: parseInt(styleHeight, 10) });
         }
         // Fetch image dimensions only if they aren't supplied or if with or height is missing
         Image.getSize(

--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Image, View } from 'react-native';
+import { Image, View, Text } from 'react-native';
 import PropTypes from 'prop-types';
 
 const DEFAULT_WIDTH = 100;
@@ -16,6 +16,7 @@ export default class HTMLImage extends PureComponent {
 
     static propTypes = {
         source: PropTypes.object.isRequired,
+        alt: PropTypes.string,
         style: Image.propTypes.style,
         imagesMaxWidth: PropTypes.number
     }
@@ -77,7 +78,9 @@ export default class HTMLImage extends PureComponent {
 
     get errorImage () {
         return (
-            <View style={{ width: 50, height: 50, borderWidth: 1, borderColor: 'lightgray' }} />
+            <View style={{ width: 50, height: 50, borderWidth: 1, borderColor: 'lightgray', overflow: 'hidden', justifyContent: 'center' }}>
+                { this.props.alt ? <Text style={{ textAlign: 'center', fontStyle: 'italic' }}>{ this.props.alt }</Text> : false }
+            </View>
         );
     }
 

--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -53,12 +53,13 @@ export default class HTMLImage extends PureComponent {
         // Fetch image dimensions only if they aren't supplied or if with or height is missing
         Image.getSize(
             source.uri,
-            (width, height) => {
-                this.setState({
-                    width: imagesMaxWidth && width > imagesMaxWidth ? imagesMaxWidth : width,
-                    height: imagesMaxWidth && width > imagesMaxWidth ? height / (width / imagesMaxWidth) : height,
-                    error: false
-                });
+            (originalWidth, originalHeight) => {
+                if (!imagesMaxWidth) {
+                    return this.setState({ width: originalWidth, height: originalHeight });
+                }
+                const optimalWidth = imagesMaxWidth <= originalWidth ? imagesMaxWidth : originalWidth;
+                const optimalHeight = (optimalWidth * originalHeight) / originalWidth;
+                this.setState({ width: optimalWidth, height: optimalHeight, error: false });
             },
             () => {
                 this.setState({ error: true });

--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -57,7 +57,10 @@ export default class HTMLImage extends PureComponent {
         const { styleWidth, styleHeight } = this.getDimensionsFromStyle(style, height, width);
 
         if (styleWidth && styleHeight) {
-            return this.setState({ width: parseInt(styleWidth, 10), height: parseInt(styleHeight, 10) });
+            return this.setState({
+                width: typeof styleWidth === 'string' && styleWidth.search('%') !== -1 ? styleWidth : parseInt(styleWidth, 10),
+                height: typeof styleHeight === 'string' && styleHeight.search('%') !== -1 ? styleHeight : parseInt(styleHeight, 10)
+            });
         }
         // Fetch image dimensions only if they aren't supplied or if with or height is missing
         Image.getSize(

--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -2,15 +2,12 @@ import React, { PureComponent } from 'react';
 import { Image, View, Text } from 'react-native';
 import PropTypes from 'prop-types';
 
-const DEFAULT_WIDTH = 100;
-const DEFAULT_HEIGHT = 100;
-
 export default class HTMLImage extends PureComponent {
     constructor (props) {
         super(props);
         this.state = {
-            width: DEFAULT_WIDTH,
-            height: DEFAULT_HEIGHT
+            width: props.imagesInitialDimensions.width,
+            height: props.imagesInitialDimensions.height
         };
     }
 
@@ -20,7 +17,18 @@ export default class HTMLImage extends PureComponent {
         height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         style: Image.propTypes.style,
-        imagesMaxWidth: PropTypes.number
+        imagesMaxWidth: PropTypes.number,
+        imagesInitialDimensions: PropTypes.shape({
+            width: PropTypes.number,
+            height: PropTypes.number
+        })
+    }
+
+    static defaultProps = {
+        imagesInitialDimensions: {
+            width: 100,
+            height: 100
+        }
     }
 
     componentDidMount () {

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -4,7 +4,7 @@ import { _constructStyles } from './HTMLStyles';
 import HTMLImage from './HTMLImage';
 
 export function a (htmlAttribs, children, convertedCSSStyles, passProps) {
-    const { parentWrapper, onLinkPress, key } = passProps;
+    const { parentWrapper, onLinkPress, key, data } = passProps;
     const style = _constructStyles({
         tagName: 'a',
         htmlAttribs,
@@ -19,13 +19,13 @@ export function a (htmlAttribs, children, convertedCSSStyles, passProps) {
     if (parentWrapper === 'Text') {
         return (
             <Text {...passProps} style={style} onPress={onPress} key={key}>
-                { children }
+                { children || data }
             </Text>
         );
     } else {
         return (
             <TouchableOpacity onPress={onPress} key={key}>
-                { children }
+                { children || data }
             </TouchableOpacity>
         );
     }

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity, Text, View, WebView } from 'react-native';
+import { TouchableOpacity, Text, View, WebView, Dimensions } from 'react-native';
 import { _constructStyles } from './HTMLStyles';
 import HTMLImage from './HTMLImage';
 
@@ -109,19 +109,28 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
         return false;
     }
 
+    const viewportWidth = Dimensions.get('window').width;
     const style = _constructStyles({
         tagName: 'iframe',
         htmlAttribs,
         passProps,
         styleSet: 'VIEW',
         additionalStyles: [
-            htmlAttribs.height ? { height: parseInt(htmlAttribs.height, 10) } : {},
-            htmlAttribs.width ? { width: parseInt(htmlAttribs.width, 10) } : {}
+            {
+                height: htmlAttribs.height ?
+                    parseInt(htmlAttribs.height, 10) :
+                    undefined
+            },
+            {
+                width: htmlAttribs.width && htmlAttribs.width <= viewportWidth ?
+                    parseInt(htmlAttribs.width, 10) :
+                    viewportWidth
+            }
         ]
     });
 
     return (
-        <WebView key={passProps.key} source={{ uri: htmlAttribs.src }} style={style} {...passProps} />
+        <WebView key={passProps.key} source={{ uri: htmlAttribs.src }} style={style} />
     );
 }
 

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -61,9 +61,19 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
     children = children && children.map((child, index) => {
         const rawChild = rawChildren[index];
         let prefix = false;
+        const rendererArgs = [
+            htmlAttribs,
+            children,
+            convertedCSSStyles,
+            {
+                ...passProps,
+                index
+            }
+        ];
+
         if (rawChild) {
             if (rawChild.parentTag === 'ul') {
-                prefix = listsPrefixesRenderers && listsPrefixesRenderers.ul ? listsPrefixesRenderers.ul(...arguments) : (
+                prefix = listsPrefixesRenderers && listsPrefixesRenderers.ul ? listsPrefixesRenderers.ul(...rendererArgs) : (
                     <View style={{
                         marginRight: 10,
                         width: baseFontSize / 2.8,
@@ -74,7 +84,7 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
                     }} />
                 );
             } else if (rawChild.parentTag === 'ol') {
-                prefix = listsPrefixesRenderers && listsPrefixesRenderers.ol ? listsPrefixesRenderers.ol(...arguments) : (
+                prefix = listsPrefixesRenderers && listsPrefixesRenderers.ol ? listsPrefixesRenderers.ol(...rendererArgs) : (
                     <Text style={{ marginRight: 5, fontSize: baseFontSize }}>{ index + 1 })</Text>
                 );
             }

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -48,7 +48,8 @@ export function img (htmlAttribs, children, convertedCSSStyles, passProps = {}) 
 }
 
 export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
-    const { rawChildren, nodeIndex, key, baseFontSize, listsPrefixesRenderers } = passProps;
+    const { rawChildren, nodeIndex, key, baseFontStyle, listsPrefixesRenderers } = passProps;
+    const baseFontSize = baseFontStyle.fontSize || 14;
     children = children && children.map((child, index) => {
         const rawChild = rawChildren[index];
         let prefix = false;
@@ -71,7 +72,7 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
             }
         }
         return (
-            <View key={`list-${nodeIndex}-${index}`} style={{ flexDirection: 'row', marginBottom: 10 }}>
+            <View key={`list-${nodeIndex}-${index}-${key}`} style={{ flexDirection: 'row', marginBottom: 10 }}>
                 { prefix }
                 <View style={{ flex: 1 }}>{ child }</View>
             </View>

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -111,7 +111,7 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
     });
 
     return (
-        <WebView source={{ uri: htmlAttribs.src }} style={style} {...passProps} />
+        <WebView key={passProps.key} source={{ uri: htmlAttribs.src }} style={style} {...passProps} />
     );
 }
 
@@ -121,8 +121,8 @@ export function br (htlmAttribs, children, convertedCSSStyles, passProps) {
     );
 }
 
-export function textwrapper (htmlAttribs, children, convertedCSSStyles) {
+export function textwrapper (htmlAttribs, children, convertedCSSStyles, { key }) {
     return (
-        <Text style={convertedCSSStyles}>{ children }</Text>
+        <Text key={key} style={convertedCSSStyles}>{ children }</Text>
     );
 }

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -32,7 +32,8 @@ export function a (htmlAttribs, children, convertedCSSStyles, passProps) {
 }
 
 export function img (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
-    if (!htmlAttribs.src) {
+    const { src, alt, width, height } = htmlAttribs;
+    if (!src) {
         return false;
     }
 
@@ -43,7 +44,14 @@ export function img (htmlAttribs, children, convertedCSSStyles, passProps = {}) 
         styleSet: 'IMAGE'
     });
     return (
-        <HTMLImage source={{ uri: htmlAttribs.src }} alt={htmlAttribs.alt} style={style} {...passProps} />
+        <HTMLImage
+          source={{ uri: src }}
+          alt={alt}
+          width={width}
+          height={height}
+          style={style}
+          {...passProps}
+        />
     );
 }
 

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -48,13 +48,13 @@ export function img (htmlAttribs, children, convertedCSSStyles, passProps = {}) 
 }
 
 export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
-    const { rawChildren, nodeIndex, key, baseFontSize } = passProps;
+    const { rawChildren, nodeIndex, key, baseFontSize, listsPrefixesRenderers } = passProps;
     children = children && children.map((child, index) => {
         const rawChild = rawChildren[index];
         let prefix = false;
         if (rawChild) {
             if (rawChild.parentTag === 'ul') {
-                prefix = (
+                prefix = listsPrefixesRenderers && listsPrefixesRenderers.ul ? listsPrefixesRenderers.ul(...arguments) : (
                     <View style={{
                         marginRight: 10,
                         width: baseFontSize / 2.8,
@@ -65,7 +65,7 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
                     }} />
                 );
             } else if (rawChild.parentTag === 'ol') {
-                prefix = (
+                prefix = listsPrefixesRenderers && listsPrefixesRenderers.ol ? listsPrefixesRenderers.ol(...arguments) : (
                     <Text style={{ marginRight: 5, fontSize: baseFontSize }}>{ index + 1 })</Text>
                 );
             }

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -43,7 +43,7 @@ export function img (htmlAttribs, children, convertedCSSStyles, passProps = {}) 
         styleSet: 'IMAGE'
     });
     return (
-        <HTMLImage source={{ uri: htmlAttribs.src }} style={style} {...passProps} />
+        <HTMLImage source={{ uri: htmlAttribs.src }} alt={htmlAttribs.alt} style={style} {...passProps} />
     );
 }
 

--- a/src/HTMLStyles.js
+++ b/src/HTMLStyles.js
@@ -30,7 +30,7 @@ function cssStringToObject (str) {
 export function _constructStyles ({ tagName, htmlAttribs, passProps, additionalStyles, styleSet = 'VIEW', baseFontSize }) {
     let defaultTextStyles = generateDefaultTextStyles(baseFontSize);
     let defaultBlockStyles = generateDefaultBlockStyles(baseFontSize);
-    return [
+    let style = [
         (styleSet === 'VIEW' ? defaultBlockStyles : defaultTextStyles)[tagName],
         passProps.tagsStyles ? passProps.tagsStyles[tagName] : undefined,
         _getElementClassStyles(htmlAttribs, passProps.classesStyles),
@@ -40,10 +40,14 @@ export function _constructStyles ({ tagName, htmlAttribs, passProps, additionalS
                 STYLESETS[styleSet],
                 { parentTag: tagName }
             ) :
-            undefined,
-        additionalStyles || undefined
-    ]
-    .filter((style) => style !== undefined);
+            undefined
+    ];
+
+    if (additionalStyles) {
+        style = style.concat(!additionalStyles.length ? [additionalStyles] : additionalStyles);
+    }
+
+    return style.filter((style) => style !== undefined);
 }
 
 /**

--- a/src/HTMLStyles.js
+++ b/src/HTMLStyles.js
@@ -7,7 +7,7 @@ import checkPropTypes from './checkPropTypes';
 * @param str: the style string
 * @return the style as an obect
 */
-function cssStringToObject (str) {
+export function cssStringToObject (str) {
     return str
         .split(';')
         .map((prop) => prop.split(':'))
@@ -17,6 +17,14 @@ function cssStringToObject (str) {
             }
             return acc;
         }, {});
+}
+
+export function cssObjectToString (obj) {
+    let string = '';
+    Object.keys(obj).forEach((style) => {
+        string += `${style}:${obj[style]};`;
+    });
+    return string;
 }
 
 /**

--- a/src/HTMLStyles.js
+++ b/src/HTMLStyles.js
@@ -32,7 +32,7 @@ export function _constructStyles ({ tagName, htmlAttribs, passProps, additionalS
     let defaultBlockStyles = generateDefaultBlockStyles(baseFontSize);
     return [
         (styleSet === 'VIEW' ? defaultBlockStyles : defaultTextStyles)[tagName],
-        passProps.htmlStyles ? passProps.htmlStyles[tagName] : undefined,
+        passProps.tagsStyles ? passProps.tagsStyles[tagName] : undefined,
         _getElementClassStyles(htmlAttribs, passProps.classesStyles),
         htmlAttribs.style ?
             cssStringToRNStyle(

--- a/src/HTMLUtils.js
+++ b/src/HTMLUtils.js
@@ -13,6 +13,9 @@ export const TEXT_TAGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'figcaption', 'p',
     'dfn', 'i', 'kbd', 'mark', 'q', 'rt', 's', 'samp', 'small', 'big', 'span', 'strong', 'sub', 'sup', 'time', 'u', 'var', 'wbr',
     'del', 'ins', 'blink', 'font', 'em', 'bold', 'br'];
 
+// These tags can either be mapped to View or Text wrappers, depending solely on their children
+export const MIXED_TAGS = ['a'];
+
 // These text tags shouldn't be associated with their siblings in the associateRawTags method
 export const TEXT_TAGS_IGNORING_ASSOCIATION = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
 

--- a/src/HTMLUtils.js
+++ b/src/HTMLUtils.js
@@ -2,6 +2,13 @@ import TextStylesPropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
 import ViewStylesPropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes';
 import ImageStylesPropTypes from 'react-native/Libraries/Image/ImageStylePropTypes';
 
+// Filter prop-types that are only applicable to <Text> and not <View>
+export let TextOnlyPropTypes = {};
+Object.keys(TextStylesPropTypes).forEach((prop) => {
+    if (!ViewStylesPropTypes[prop]) {
+        TextOnlyPropTypes[prop] = TextStylesPropTypes[prop];
+    }
+});
 
 // These tags should ALWAYS be mapped to View wrappers
 export const BLOCK_TAGS = ['address', 'article', 'aside', 'footer', 'hgroup', 'nav', 'section', 'blockquote', 'dd',

--- a/src/HTMLUtils.js
+++ b/src/HTMLUtils.js
@@ -1,12 +1,15 @@
-import _RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes';
-import _RNViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes';
-import _RNImageStylePropTypes from 'react-native/Libraries/Image/ImageStylePropTypes';
+import TextStylesPropTypes from 'react-native/Libraries/Text/TextStylePropTypes';
+import ViewStylesPropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes';
+import ImageStylesPropTypes from 'react-native/Libraries/Image/ImageStylePropTypes';
 
-export const BLOCK_TAGS = ['address', 'article', 'aside', 'footer', 'hgroup', 'nav', 'section', 'blockquote', 'dd', 'div',
+
+// These tags should ALWAYS be mapped to View wrappers
+export const BLOCK_TAGS = ['address', 'article', 'aside', 'footer', 'hgroup', 'nav', 'section', 'blockquote', 'dd',
     'dl', 'dt', 'figure', 'hr', 'li', 'main', 'ol', 'ul', 'cite', 'data', 'rp', 'rtc', 'ruby', 'area',
     'img', 'map', 'center'];
 
-export const TEXT_TAGS = ['a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'figcaption', 'p', 'pre', 'abbr', 'b', 'bdi', 'bdo', 'code',
+// These tags should ALWAYS be mapped to Text wrappers
+export const TEXT_TAGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'figcaption', 'p', 'pre', 'abbr', 'b', 'bdi', 'bdo', 'code',
     'dfn', 'i', 'kbd', 'mark', 'q', 'rt', 's', 'samp', 'small', 'big', 'span', 'strong', 'sub', 'sup', 'time', 'u', 'var', 'wbr',
     'del', 'ins', 'blink', 'font', 'em', 'bold', 'br'];
 
@@ -27,12 +30,12 @@ export const PERC_SUPPORTED_STYLES = [
 ];
 
 // We have to do some munging here as the objects are wrapped
-const RNTextStylePropTypes = Object.keys(_RNTextStylePropTypes)
-    .reduce((acc, k) => { acc[k] = _RNTextStylePropTypes[k]; return acc; }, {});
-const RNViewStylePropTypes = Object.keys(_RNViewStylePropTypes)
-    .reduce((acc, k) => { acc[k] = _RNViewStylePropTypes[k]; return acc; }, {});
-const RNImageStylePropTypes = Object.keys(_RNImageStylePropTypes)
-    .reduce((acc, k) => { acc[k] = _RNImageStylePropTypes[k]; return acc; }, {});
+const RNTextStylePropTypes = Object.keys(TextStylesPropTypes)
+    .reduce((acc, k) => { acc[k] = TextStylesPropTypes[k]; return acc; }, {});
+const RNViewStylePropTypes = Object.keys(ViewStylesPropTypes)
+    .reduce((acc, k) => { acc[k] = ViewStylesPropTypes[k]; return acc; }, {});
+const RNImageStylePropTypes = Object.keys(ImageStylesPropTypes)
+    .reduce((acc, k) => { acc[k] = ImageStylesPropTypes[k]; return acc; }, {});
 
 export const STYLESETS = Object.freeze({ VIEW: 'view', TEXT: 'text', IMAGE: 'image' });
 

--- a/src/HTMLUtils.js
+++ b/src/HTMLUtils.js
@@ -3,17 +3,20 @@ import _RNViewStylePropTypes from 'react-native/Libraries/Components/View/ViewSt
 import _RNImageStylePropTypes from 'react-native/Libraries/Image/ImageStylePropTypes';
 
 export const BLOCK_TAGS = ['address', 'article', 'aside', 'footer', 'hgroup', 'nav', 'section', 'blockquote', 'dd', 'div',
-'dl', 'dt', 'figure', 'hr', 'li', 'main', 'ol', 'ul', 'cite', 'data', 'rp', 'rtc', 'ruby', 'area',
-'img', 'map', 'center'];
+    'dl', 'dt', 'figure', 'hr', 'li', 'main', 'ol', 'ul', 'cite', 'data', 'rp', 'rtc', 'ruby', 'area',
+    'img', 'map', 'center'];
 
 export const TEXT_TAGS = ['a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'figcaption', 'p', 'pre', 'abbr', 'b', 'bdi', 'bdo', 'code',
-'dfn', 'i', 'kbd', 'mark', 'q', 'rt', 's', 'samp', 'small', 'big', 'span', 'strong', 'sub', 'sup', 'time', 'u', 'var', 'wbr',
-'del', 'ins', 'blink', 'font', 'em', 'bold', 'br'];
+    'dfn', 'i', 'kbd', 'mark', 'q', 'rt', 's', 'samp', 'small', 'big', 'span', 'strong', 'sub', 'sup', 'time', 'u', 'var', 'wbr',
+    'del', 'ins', 'blink', 'font', 'em', 'bold', 'br'];
+
+// These text tags shouldn't be associated with their siblings in the associateRawTags method
+export const TEXT_TAGS_IGNORING_ASSOCIATION = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
 
 export const IGNORED_TAGS = ['head', 'scripts', 'audio', 'video', 'track', 'embed', 'object', 'param', 'source', 'canvas', 'noscript',
-'caption', 'col', 'colgroup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'button', 'datalist', 'fieldset', 'form',
-'input', 'label', 'legend', 'meter', 'optgroup', 'option', 'output', 'progress', 'select', 'textarea', 'details', 'diaglog',
-'menu', 'menuitem', 'summary'];
+    'caption', 'col', 'colgroup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'button', 'datalist', 'fieldset', 'form',
+    'input', 'label', 'legend', 'meter', 'optgroup', 'option', 'output', 'progress', 'select', 'textarea', 'details', 'diaglog',
+    'menu', 'menuitem', 'summary'];
 
 // As of react-native 0.48, this might change in the future
 export const PERC_SUPPORTED_STYLES = [


### PR DESCRIPTION
## New features

* Add `baseFontStyle` prop, **(replacing `baseFontSize` !)** allowing you to provide complete default styling to your text elements (#25)
* Add `listsPrefixesRenderers` prop, allowing you to customize the bullets and numbers rendered in your `<ul>` and `<ol>` lists
* Add `imagesInitialDimensions` prop
* Finished writing the base code for loading and parsing remote websites. Added a basic loader and error handlers.
* Add `remoteLoadingView` & `remoteErrorView` props
* Add `onParsed` prop, this is fired upon first rendering with the the parsing result of `htmlparser2` and of this module
* `HTMLImage`: render the `alt` attribute when images couldn't be displayed
* `HTMLImage`: `width` and `height` attribute now resize your image
* Add `debug` prop, printing the parsing result of `htmlparser2` and of this module after initial rendering

## Fixes

* Make `classesStyles` take precedence over `tagsStyles` (#35)
* Greatly improve text styling nested inside views
* In some cases, raw texts children weren't wrapped with their texts siblings, so their styling wouldn't apply properly
* Title tags like `<h1>`, `<h2>` and so on will always break line between each others
* `HTMLImage`: don't overscale images when `imagesMaxWidth` prop is set to a higher value than the original width of your images
* Correct some edge cases where random line breaks would randomly happen
* Properly render raw texts nested inside `<a>` tags
* `tagsStyles` is now applied `_constructStyles` so your custom renderers have proper styling
