### PR TITLE
maybe-ignoredStyles-not-work-at-a-tag@issue#59

### DIFF
--- a/src/HTMLStyles.js
+++ b/src/HTMLStyles.js
@@ -46,7 +46,7 @@ export function _constructStyles ({ tagName, htmlAttribs, passProps, additionalS
             cssStringToRNStyle(
                 htmlAttribs.style,
                 STYLESETS[styleSet],
-                { parentTag: tagName }
+                { ...passProps, parentTag: tagName }
             ) :
             undefined
     ];


### PR DESCRIPTION
There is `<a>` tag with a style within `display:inline` in the HTML content.
But RN only support display with 'none' or 'flex'.
So I get the Warning: Failed prop type: Invalid prop `display` of value `inline` supplied to `Text`, expected one of ["none","flex"].

It looks like the #59 

Then I use the `ignoredStyles={ [ 'display' ] }`, but it does not work.

Then I read the source code, and find the ignoredStyles is not used at the renderer of `<a>` tag.

So maybe this PR will help.