### PR TITLE
Fix missing custom styles for ul/ol tags

### DIFF
--- a/src/HTMLDefaultStyles.js
+++ b/src/HTMLDefaultStyles.js
@@ -4,11 +4,11 @@ export function generateDefaultBlockStyles (baseFontSize = BASE_FONT_SIZE) {
     return {
         div: { },
         ul: {
-            paddingLeft: 40,
+            paddingLeft: 20,
             marginBottom: baseFontSize
         },
         ol: {
-            paddingLeft: 40,
+            paddingLeft: 20,
             marginBottom: baseFontSize
         },
         iframe: {

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -58,6 +58,14 @@ export function img (htmlAttribs, children, convertedCSSStyles, passProps = {}) 
 export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
     const { rawChildren, nodeIndex, key, baseFontStyle, listsPrefixesRenderers } = passProps;
     const baseFontSize = baseFontStyle.fontSize || 14;
+
+    const style = _constructStyles({
+        tagName: 'ul',
+        htmlAttribs,
+        passProps,
+        styleSet: 'VIEW'
+    });
+
     children = children && children.map((child, index) => {
         const rawChild = rawChildren[index];
         let prefix = false;
@@ -97,7 +105,7 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
         );
     });
     return (
-        <View style={{ paddingLeft: 20 }} key={key}>
+        <View style={style} key={key}>
             { children }
         </View>
     );


### PR DESCRIPTION
The ul/ol renderer function was hardcoding the style. This PR gets the the style using the `_constructStyles` so behaves like the other tag renderers.