### PR TITLE
v3.6.0

### DIFF
--- a/Demo/src/snippets.js
+++ b/Demo/src/snippets.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View } from 'react-native';
+import { View, Text } from 'react-native';
 import { _constructStyles } from 'react-native-render-html/src/HTMLStyles';
+import { getParentsTagsRecursively } from 'react-native-render-html/src/HTMLUtils';
 
 export const paragraphs = `
 <p style="font-size:1.3em;">This paragraph is styled a font size set in em !</p>
@@ -161,7 +162,29 @@ export const alteration = `
     <h2>Using alterChildren</h2>
     <p>Let's remove the first two elements of the next ordered list</p>
     <ol><li>One</li><li>Two</li><li>Three</li><li>Four</li></ol>
+    <h2>Using alterNode</h2>
+    <p>alterNode lets you change the values parsed from your HTML before it's rendered. It's extremely powerful as a last resort to add some very specific styling or circumvent rendering problems</p>
+    <p>Let's make the color of links inside a <em>div</em> red !</p>
+    <p><a href="http://google.fr">This is a lame link inside a paragraph.</a></p>
+    <div><a href="http://google.fr">This is a very cool link inside a div</a></div>
 `;
+
+export const inlineCustomTags = `
+    <p>Foo <MyTag></MyTag> Baz </p>
+    <p>Foo <myothertag></myothertag> baz</p>
+`;
+
+function myTagRenderer (htmlAttribs, children) {
+    return (
+        <Text>Bar</Text>
+    );
+}
+
+function myOtherTagRenderer () {
+    return (
+        <Text>this should break the line</Text>
+    );
+}
 
 export default {
     paragraphs: {
@@ -209,7 +232,7 @@ export default {
     parseRemoteHTML: { name: 'Remote HTML', props: { html: undefined, uri: 'http://motherfuckingwebsite.com', ignoredTags: ['script'] } },
     iframes: { name: 'Iframes' },
     alteration: {
-        name: 'Altering data & chlidren',
+        name: 'Altering data, chlidren & nodes',
         props: {
             alterData: (node) => {
                 let { parent, data } = node;
@@ -226,6 +249,22 @@ export default {
                 } else {
                     return false;
                 }
+            },
+            alterNode: (node) => {
+                const { name, parent } = node;
+                if (name === 'a' && parent && parent.name === 'div') {
+                    node.attribs = { ...(node.attribs || {}), style: 'color:red;' };
+                    return node;
+                }
+            }
+        }
+    },
+    inlineCustomTags: {
+        name: 'Inline custom tags',
+        props: {
+            renderers: {
+                mytag: { renderer: myTagRenderer, wrapper: 'Text' },
+                myothertag: myOtherTagRenderer
             }
         }
     }

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -295,6 +295,8 @@ export default class HTML extends PureComponent {
                 } else if (TEXT_TAGS.indexOf(name.toLowerCase()) !== -1 || MIXED_TAGS.indexOf(name.toLowerCase()) !== -1) {
                     // We are able to nest its children inside a Text
                     return { wrapper: 'Text', children, attribs, parent, tagName: name, parentTag };
+                } else if (this.renderers[name] && this.renderers[name].wrapper) {
+                    return { wrapper: this.renderers[name].wrapper, children, attribs, parent, tagName: name, parentTag };
                 }
                 return { wrapper: 'View', children, attribs, parent, tagName: name, parentTag };
             }
@@ -400,8 +402,17 @@ export default class HTML extends PureComponent {
                 false;
 
             if (this.renderers[tagName]) {
+                const customRenderer =
+                    typeof this.renderers[tagName] === 'function' ?
+                        this.renderers[tagName] :
+                        this.renderers[tagName].renderer;
+
+                if (!customRenderer || typeof customRenderer !== 'function') {
+                    console.warn(`Custom renderer for ${tagName} supplied incorrectly. Please check out the docs.`);
+                    return undefined;
+                }
                 // If a custom renderer is available for this tag
-                return this.renderers[tagName](
+                return customRenderer(
                     attribs,
                     childElements,
                     convertedCSSStyles,

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -19,6 +19,7 @@ export default class HTML extends PureComponent {
         ignoreNodesFunction: PropTypes.func,
         alterData: PropTypes.func,
         alterChildren: PropTypes.func,
+        alterNode: PropTypes.func,
         html: PropTypes.string,
         uri: PropTypes.string,
         tagsStyles: PropTypes.object,
@@ -242,9 +243,8 @@ export default class HTML extends PureComponent {
      * @memberof HTML
      */
     mapDOMNodesTORNElements (DOMNodes, parentTag = false) {
-        const { ignoreNodesFunction, ignoredTags, alterData, alterChildren, tagsStyles, classesStyles } = this.props;
+        const { ignoreNodesFunction, ignoredTags, alterNode, alterData, alterChildren, tagsStyles, classesStyles } = this.props;
         let RNElements = DOMNodes.map((node, nodeIndex) => {
-            const { type, attribs, name, parent } = node;
             let { children, data } = node;
             if (ignoreNodesFunction && ignoreNodesFunction(node, parentTag) === true) {
                 return false;
@@ -252,6 +252,13 @@ export default class HTML extends PureComponent {
             if (ignoredTags.map((tag) => tag.toLowerCase()).indexOf(node.name && node.name.toLowerCase()) !== -1) {
                 return false;
             }
+
+            if (alterNode) {
+                const alteredNode = alterNode(node);
+                node = alteredNode || node;
+            }
+            const { type, attribs, name, parent } = node;
+
             if (alterData && data) {
                 const alteredData = alterData(node);
                 data = alteredData || data;

--- a/src/HTMLDefaultStyles.js
+++ b/src/HTMLDefaultStyles.js
@@ -4,11 +4,11 @@ export function generateDefaultBlockStyles (baseFontSize = BASE_FONT_SIZE) {
     return {
         div: { },
         ul: {
-            paddingLeft: 40,
+            paddingLeft: 20,
             marginBottom: baseFontSize
         },
         ol: {
-            paddingLeft: 40,
+            paddingLeft: 20,
             marginBottom: baseFontSize
         },
         iframe: {

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -58,6 +58,14 @@ export function img (htmlAttribs, children, convertedCSSStyles, passProps = {}) 
 export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
     const { rawChildren, nodeIndex, key, baseFontStyle, listsPrefixesRenderers } = passProps;
     const baseFontSize = baseFontStyle.fontSize || 14;
+
+    const style = _constructStyles({
+        tagName: 'ul',
+        htmlAttribs,
+        passProps,
+        styleSet: 'VIEW'
+    });
+
     children = children && children.map((child, index) => {
         const rawChild = rawChildren[index];
         let prefix = false;
@@ -97,7 +105,7 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
         );
     });
     return (
-        <View style={{ paddingLeft: 20 }} key={key}>
+        <View style={style} key={key}>
             { children }
         </View>
     );

--- a/src/HTMLStyles.js
+++ b/src/HTMLStyles.js
@@ -46,7 +46,7 @@ export function _constructStyles ({ tagName, htmlAttribs, passProps, additionalS
             cssStringToRNStyle(
                 htmlAttribs.style,
                 STYLESETS[styleSet],
-                { parentTag: tagName }
+                { ...passProps, parentTag: tagName }
             ) :
             undefined
     ];

--- a/src/HTMLUtils.js
+++ b/src/HTMLUtils.js
@@ -53,3 +53,23 @@ export const stylePropTypes = {};
 stylePropTypes[STYLESETS.VIEW] = Object.assign({}, RNViewStylePropTypes);
 stylePropTypes[STYLESETS.TEXT] = Object.assign({}, RNViewStylePropTypes, RNTextStylePropTypes);
 stylePropTypes[STYLESETS.IMAGE] = Object.assign({}, RNViewStylePropTypes, RNImageStylePropTypes);
+
+/**
+ * Returns an array with the tagname of every parent of a node.
+ * Returns an empty array if nothing is found.
+ * @export
+ * @param {any} parent a parsed HTML node, from alterChildren for example
+ * @param {any} tags you don't need to supply this yourself
+ * @returns {array}
+ */
+export function getParentsTagsRecursively (parent, tags = []) {
+    if (!parent) {
+        return tags;
+    }
+    parent.name && tags.push(parent.name);
+    if (parent.parent) {
+        return getParentsTagsRecursively(parent.parent, tags);
+    } else {
+        return tags;
+    }
+}


### PR DESCRIPTION
## New features

* Add `alterNode` prop that lets you change the values parsed from your HTML before it's rendered. It's extremely powerful as a last resort to add some very specific styling or circumvent rendering problems.
* You can now set your custom renderers as inline components. By default, your renderers will still behave as blocks.

## Fixes

* `<ul>` and `<ol>` styles aren't hardcoded anymore, you can now style them normally. (thanks @jonathonlui !)
* `<a>` tags will properly use your `ignoredStyles` prop (thanks @YeatsLu !)