### PR TITLE
Add missing parentTag

### DIFF
--- a/src/HTML.js
+++ b/src/HTML.js
@@ -280,6 +280,7 @@ export default class HTML extends PureComponent {
                     data: data.replace(/(\r\n|\n|\r)/gm, ''), // remove linebreaks
                     attribs: attribs || {},
                     parent,
+                    parentTag: parent && parent.name,
                     tagName: name || 'rawtext'
                 };
             }


### PR DESCRIPTION
Using `tagsStyles`, some font styles were not applied to text, as `parentTag` was missing in all elements. 
This PR adds missing `parentTag`, if it exist.