### PR TITLE
Parse DOM after changing `imagesMaxWidth`

### DIFF
--- a/src/HTML.js
+++ b/src/HTML.js
@@ -83,7 +83,7 @@ export default class HTML extends PureComponent {
     }
 
     componentDidUpdate (prevProps, prevState) {
-        if (this.state.dom !== prevState.dom) {
+        if (this.state.dom !== prevState.dom || this.props.imagesMaxWidth !== prevProps.imagesMaxWidth) {
             this.parseDOM(this.state.dom);
         }
     }


### PR DESCRIPTION
This commit improve `componentDidUpdate` behaviour and changing `imagesMaxWidth` prop causes a new render cycle through a DOM. It is useful for responsive `HTML` component. For example, if device orientation is changed it may causes an update of `imagesMaxWidth` value from parent component (as a result of `onLayout` callback) and if `HTML` uses custom `renderers` its internal logic requires update of `this.state.dom` value to trigger new `parseDOM`.