### PR TITLE
Allow text to be selected and copied

### DIFF
--- a/src/HTML.js
+++ b/src/HTML.js
@@ -34,7 +34,8 @@ export default class HTML extends PureComponent {
             height: PropTypes.number
         }),
         emSize: PropTypes.number.isRequired,
-        baseFontStyle: PropTypes.object.isRequired
+        baseFontStyle: PropTypes.object.isRequired,
+        textSelectable: PropTypes.bool
     }
 
     static defaultProps = {
@@ -46,7 +47,8 @@ export default class HTML extends PureComponent {
         ignoredStyles: [],
         baseFontStyle: { fontSize: 14 },
         tagsStyles: {},
-        classesStyles: {}
+        classesStyles: {},
+        textSelectable: false
     }
 
     constructor (props) {
@@ -447,8 +449,10 @@ export default class HTML extends PureComponent {
             ]
             .filter((s) => s !== undefined);
 
+            const extraProps = {};
+            if (Wrapper === Text) extraProps.selectable = this.props.textSelectable;
             return (
-                <Wrapper key={key} style={style}>
+                <Wrapper key={key} style={style} {...extraProps}>
                     { textElement }
                     { childElements }
                 </Wrapper>

--- a/src/HTMLDefaultStyles.js
+++ b/src/HTMLDefaultStyles.js
@@ -29,6 +29,7 @@ export function generateDefaultTextStyles (baseFontSize = BASE_FONT_SIZE) {
         em: { fontStyle: 'italic' },
         i: { fontStyle: 'italic' },
         b: { fontWeight: 'bold' },
+        s: { textDecorationLine: 'line-through' },
         strong: { fontWeight: 'bold' },
         big: { fontSize: baseFontSize * 1.2 },
         small: { fontSize: baseFontSize * 0.8 },


### PR DESCRIPTION
This uses the `react-native`'s own `selectable` prop on `Text` component and allow the same behavior as if`selectable` is enabled on a normal `Text` component.

This also adds default styles for `strikethrough` (i.e. `<s>...</s>`) that is currently not supported.

![screen shot 2018-01-17 at 10 25 46 am](https://user-images.githubusercontent.com/3514188/35059669-d073b1e6-fb70-11e7-9cfd-11cb9361517c.png)

This should address https://github.com/archriss/react-native-render-html/issues/58