### PR TITLE
Pass all html attributes to onLinkPress handler

### DIFF
--- a/Demo/src/HTMLDemo.js
+++ b/Demo/src/HTMLDemo.js
@@ -24,8 +24,8 @@ export default class Demo extends Component {
         this.setCurrentExample = this.setCurrentExample.bind(this);
     }
 
-    onLinkPress (evt, href) {
-        alert(`Opened ${href} !`);
+    onLinkPress (evt, href, htmlAttribs) {
+        alert(`Opened ${href} ! Attributes:`, htmlAttribs);
     }
 
     setCurrentExample (currentExample) {

--- a/Demo/src/snippets.js
+++ b/Demo/src/snippets.js
@@ -9,7 +9,7 @@ export const paragraphs = `
 <p style="padding:10%;">This one features a padding <strong>in percentage !</strong></p>
 <hr />
 <i>Here, we have a style set on the "i" tag with the "tagsStyles" prop.</i>
-<p>And <a href="http://google.fr">This is a link !</a></p>
+<p>And <a href="http://google.fr" title="Google FR">This is a link !</a></p>
 <a href="http://google.fr"><div style="background-color: red; height: 20px; width:40px;"></div></a>
 <p class="last-paragraph">Finally, this paragraph is styled through the classesStyles prop</p>
 `;

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Prop | Description | Type | Required/Default
 `decodeEntities` | Decode HTML entities of your content | `bool` | Optional, defaults to `true`
 `imagesMaxWidth` | Resize your images to this maximum width, see [images](#images) | `number` | Optional
 `imagesInitialDimensions` | Default width and height to display while image's dimensions are being retrieved, see [images](#images) | `{ width: 100, height: 100 }` | Optional
-`onLinkPress` | Fired with the event and the href as its arguments when tapping a link | `function` | Optional
+`onLinkPress` | Fired with the event, the href and an object with all attributes of the tag as its arguments when tapping a link | `function` | Optional
 `onParsed` | Fired when your HTML content has been parsed. Also useful to tweak your rendering, see [onParsed](#onparsed) | `function` | Optional
 `tagsStyles` | Provide your styles for specific HTML tags, see [styling](#styling) | `object` | Optional
 `classesStyles` | Provide your styles for specific HTML classes, see [styling](#styling) | `object` | Optional

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -14,7 +14,7 @@ export function a (htmlAttribs, children, convertedCSSStyles, passProps) {
     // the passed props might be altered by it !!
     const { parentWrapper, onLinkPress, key, data } = passProps;
     const onPress = (evt) => onLinkPress && htmlAttribs && htmlAttribs.href ?
-        onLinkPress(evt, htmlAttribs.href) :
+        onLinkPress(evt, htmlAttribs.href, htmlAttribs) :
         undefined;
 
     if (parentWrapper === 'Text') {


### PR DESCRIPTION
Our use case is to pass the file type as an `filetype` attribute with the tag:

```html
<a href="https://example.com/some-link-without-filetype" filetype="pdf">Link</a>
```

This way the `onLinkPress` handler can access the attributes and decide dynamically how the link should be opened.