### PR TITLE
Add maximum iframe width feature

### DIFF
--- a/src/HTML.js
+++ b/src/HTML.js
@@ -28,6 +28,7 @@ export default class HTML extends PureComponent {
         onLinkPress: PropTypes.func,
         onParsed: PropTypes.func,
         imagesMaxWidth: PropTypes.number,
+        iframeMaxWidth: PropTypes.number,
         imagesInitialDimensions: PropTypes.shape({
             width: PropTypes.number,
             height: PropTypes.number

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -117,7 +117,7 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
         return false;
     }
 
-    const viewportWidth = Dimensions.get('window').width;
+    const viewportWidth = passProps.iframeMaxWidth || Dimensions.get('window').width;
     const style = _constructStyles({
         tagName: 'iframe',
         htmlAttribs,


### PR DESCRIPTION
Image width can be limited, but I ran into an issue where iframe was rendered too wide. Here is a patch to add iframeMaxWidth in the same style as imageMaxWidth.