### PR TITLE
Add allowedStyles prop for specifying allowed CSS properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Prop | Description | Type | Required/Default
 `alterChildren` | Target some specific nested children and change them, see [altering content](#altering-content) | `function` | Optional
 `alterNode` | Target a specific node and change it, see [altering content](#altering-content) | `function` | Optional
 `ignoredTags` | HTML tags you don't want rendered, see [ignoring HTML content](#ignoring-html-content) | `array` | Optional, `['head', 'scripts', ...]`
+`allowedStyles`| Allow render only certain CSS style properties and ignore every other. If you have some property both in `allowedStyles` and `ignoredStyles`, it will be ignored anyway. | `array` | Optional, everything is allowed by default
 `ignoredStyles` | CSS styles from the `style` attribute you don't want rendered, see [ignoring HTML content](#ignoring-html-content) | `array` | Optional
 `ignoreNodesFunction` | Return true in this custom function to ignore nodes very precisely, see [ignoring HTML content](#ignoring-html-content) | `function` | Optional
 `debug` | Prints the parsing result from htmlparser2 and render-html after the initial render | `bool` | Optional, defaults to `false`

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -12,6 +12,7 @@ export default class HTML extends PureComponent {
         renderers: PropTypes.object.isRequired,
         ignoredTags: PropTypes.array.isRequired,
         ignoredStyles: PropTypes.array.isRequired,
+        allowedStyles: PropTypes.array,
         decodeEntities: PropTypes.bool.isRequired,
         debug: PropTypes.bool.isRequired,
         listsPrefixesRenderers: PropTypes.object,
@@ -393,7 +394,7 @@ export default class HTML extends PureComponent {
      * @memberof HTML
      */
     renderRNElements (RNElements, parentWrapper = 'root', parentIndex = 0, props = this.props) {
-        const { tagsStyles, classesStyles, emSize, ignoredStyles } = props;
+        const { tagsStyles, classesStyles, emSize, ignoredStyles, allowedStyles } = props;
         return RNElements && RNElements.length ? RNElements.map((element, index) => {
             const { attribs, data, tagName, parentTag, children, nodeIndex, wrapper } = element;
             const Wrapper = wrapper === 'Text' ? Text : View;
@@ -403,7 +404,7 @@ export default class HTML extends PureComponent {
                     cssStringToRNStyle(
                         attribs.style,
                         Wrapper === Text ? STYLESETS.TEXT : STYLESETS.VIEW, // proper prop-types validation
-                        { parentTag: tagName, emSize, ignoredStyles }
+                        { parentTag: tagName, emSize, ignoredStyles, allowedStyles }
                     ) :
                     {};
 

--- a/src/HTMLStyles.js
+++ b/src/HTMLStyles.js
@@ -101,9 +101,10 @@ export function _getElementCSSClasses (htmlAttribs) {
  * @param {object} { parentTag, emSize, ignoredStyles }
  * @returns {object}
  */
-function cssToRNStyle (css, styleset, { parentTag, emSize, ignoredStyles }) {
+function cssToRNStyle (css, styleset, { parentTag, emSize, ignoredStyles, allowedStyles }) {
     const styleProps = stylePropTypes[styleset];
     return Object.keys(css)
+        .filter((key) => allowedStyles ? allowedStyles.indexOf(key) !== -1 : true)
         .filter((key) => (ignoredStyles || []).indexOf(key) === -1)
         .map((key) => [key, css[key]])
         .map(([key, value]) => {


### PR DESCRIPTION
Add new prop `allowedStyles` which is useful when you want
allow render only certain CSS style properties and ignore any other.