### PR TITLE
Fix converting of the fontWeight property

### DIFF
--- a/src/HTMLStyles.js
+++ b/src/HTMLStyles.js
@@ -140,7 +140,7 @@ function cssToRNStyle (css, styleset, { parentTag, emSize, ignoredStyles, allowe
                     }
                     // See if we can convert a 20px to a 20 automagically
                     const numericValue = parseFloat(value.replace('px', ''));
-                    if (!isNaN(numericValue)) {
+                    if (key !== 'fontWeight' && !isNaN(numericValue)) {
                         testStyle[key] = numericValue;
                         if (checkPropTypes(styleProp, testStyle, key, 'react-native-render-html') == null) {
                             return [key, numericValue];


### PR DESCRIPTION
Fixes #111 

Addresses issues when `fontWeight` property mistakenly got converted from string to a number. This resulted in crashes due to the wrong type.