### PR TITLE
Fix deprecation warnings for componentWillReceiveProps, ...WillUpdate.

### DIFF
--- a/src/HTML.js
+++ b/src/HTML.js
@@ -63,36 +63,28 @@ export default class HTML extends PureComponent {
             ...HTMLRenderers,
             ...(this.props.renderers || {})
         };
-    }
 
-    componentWillMount () {
-        this.generateDefaultStyles();
+        this.generateDefaultStyles(props.baseFontStyle);
     }
 
     componentDidMount () {
         this.registerDOM();
     }
 
-    componentWillReceiveProps (nextProps) {
-        const { html, uri, renderers } = this.props;
+    componentDidUpdate(prevProps, prevState) {
+        const { html, uri, renderers } = prevProps;
+        let doParseDOM = false;
 
-        this.generateDefaultStyles(nextProps.baseFontStyle);
-        if (renderers !== nextProps.renderers) {
-            this.renderers = { ...HTMLRenderers, ...(nextProps.renderers || {}) };
+        this.generateDefaultStyles(this.props.baseFontStyle);
+        if (renderers !== this.props.renderers) {
+            this.renderers = { ...HTMLRenderers, ...(this.props.renderers || {}) };
         }
-        if (html !== nextProps.html || uri !== nextProps.uri) {
+        if (html !== this.props.html || uri !== this.props.uri) {
             // If the source changed, register the new HTML and parse it
-            this.registerDOM(nextProps);
-        } else {
-            // If it didn't, let's just parse the current DOM and re-render the nodes
-            // to compute potential style changes
-            this.parseDOM(this.state.dom, nextProps);
+            this.registerDOM(this.props);
         }
-    }
-
-    componentDidUpdate (prevProps, prevState) {
         if (this.state.dom !== prevState.dom) {
-            this.parseDOM(this.state.dom);
+            this.parseDOM(this.state.dom, this.props);
         }
     }
 

--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -35,8 +35,8 @@ export default class HTMLImage extends PureComponent {
         this.getImageSize();
     }
 
-    componentWillReceiveProps (nextProps) {
-        this.getImageSize(nextProps);
+    componentDidUpdate(prevProps, prevState) {
+        this.getImageSize(this.props);
     }
 
     getDimensionsFromStyle (style, height, width) {


### PR DESCRIPTION
RN 0.54 / React 16.3 generates warnings for deprecated lifecycle events.
Replace componentWillMount with componentDidMount.
Replace componentWillReceiveProps with componentDidUpdate and tweak logic appropriately.

See #135 