### PR TITLE
v3.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ export default class Demo extends Component {
 Prop | Description | Type | Required/Default
 ------ | ------ | ------ | ------
 `renderers` | Your [custom renderers](#creating-custom-renderers) | `object` | Optional, some default ones are supplied (`<a>`, `<img>`...)
+`renderersProps` | Set of props accessible into your [custom renderers](#creating-custom-renderers) in `passProps` (4th argument) | `object` | Optional
 `html` | HTML string to parse and render | `string` | Required
 `uri` | *(experimental)* remote website to parse and render | `string` | Optional
 `decodeEntities` | Decode HTML entities of your content | `bool` | Optional, defaults to `true`
@@ -137,7 +138,7 @@ Your renderers functions receive several arguments that will be very useful to m
 * `htmlAttribs`: attributes attached to the node, parsed in a react-native way
 * `children` : array with the children of the node
 * `convertedCSSStyles` : conversion of the `style` attribute from CSS to react-native's stylesheet
-* `passProps` : various useful information : `groupInfo`, `parentTagName`, `parentIsText`...
+* `passProps` : various useful information :  your `renderersProps`, `groupInfo`, `parentTagName`, `parentIsText`...
 
 ### Making your custom component block or inline
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-render-html",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "author": "Archriss",
   "license": "BSD-2-Clause",
   "repository": "https://github.com/archriss/react-native-render-html",

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -45,7 +45,8 @@ export default class HTML extends PureComponent {
         emSize: PropTypes.number.isRequired,
         ptSize: PropTypes.number.isRequired,
         baseFontStyle: PropTypes.object.isRequired,
-        textSelectable: PropTypes.bool
+        textSelectable: PropTypes.bool,
+        renderersProps: PropTypes.object
     }
 
     static defaultProps = {
@@ -454,12 +455,12 @@ export default class HTML extends PureComponent {
             ]
             .filter((s) => s !== undefined);
 
-            const extraProps = {};
+            const renderersProps = {};
             if (Wrapper === Text) {
-                extraProps.selectable = this.props.textSelectable;
+                renderersProps.selectable = this.props.textSelectable;
             }
             return (
-                <Wrapper key={key} style={style} {...extraProps}>
+                <Wrapper key={key} style={style} {...renderersProps}>
                     { textElement }
                     { childElements }
                 </Wrapper>

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -216,7 +216,11 @@ export default class HTML extends PureComponent {
     associateRawTexts (children) {
         for (let i = 0; i < children.length; i++) {
             const child = children[i];
-            if ((child.wrapper === 'Text' && TEXT_TAGS_IGNORING_ASSOCIATION.indexOf(child.tagName) === -1) && children.length > 1 && (!child.parent || child.parent.name !== 'p')) {
+            if (
+                (child.wrapper === 'Text' && TEXT_TAGS_IGNORING_ASSOCIATION.indexOf(child.tagName) === -1) &&
+                children.length > 1 &&
+                (!child.parent || TEXT_TAGS_IGNORING_ASSOCIATION.indexOf(child.parent.name) === -1)
+            ) {
                 // Texts outside <p> or not <p> themselves (with siblings)
                 let wrappedTexts = [];
                 for (let j = i; j < children.length; j++) {
@@ -238,7 +242,7 @@ export default class HTML extends PureComponent {
                         nodeIndex: i,
                         parent: child.parent,
                         parentTag: child.parentTag,
-                        tagName: child.parent && child.parent.name === 'li' ? 'textwrapper' : 'p',
+                        tagName: 'textwrapper',
                         wrapper: 'Text'
                     };
                 }

--- a/src/HTMLStyles.js
+++ b/src/HTMLStyles.js
@@ -64,6 +64,66 @@ export function _constructStyles ({ tagName, htmlAttribs, passProps, additionalS
 }
 
 /**
+ * Computes the styles of a text node
+ * @export
+ * @param {any} element parsed DOM node of text
+ * @param {any} passProps set of props from the HTML component
+ * @returns {object} react-native styles
+ */
+export function computeTextStyles (element, passProps) {
+    let finalStyle = {};
+
+    // Construct an array with the styles of each level of the text node, ie :
+    // [element, parent1, parent2, parent3...]
+    const parentStyles = _recursivelyComputeParentTextStyles(element, passProps);
+
+    // Only merge the keys that aren't yet applied to the final object. ie:
+    // if fontSize is already set in the first iteration, ignore the fontSize that
+    // we got from the 3rd iteration because of a class for instance, hence
+    // respecting the proper style inheritance
+    parentStyles.forEach((styles) => {
+        Object.keys(styles).forEach((styleKey) => {
+            const styleValue = styles[styleKey];
+            if (!finalStyle[styleKey]) {
+                finalStyle[styleKey] = styleValue;
+            }
+        });
+    });
+
+    // Finally, try to add the baseFontStyle values to add pontentially missing
+    // styles to each text node
+    return { ...passProps.baseFontStyle, ...finalStyle };
+}
+
+function _recursivelyComputeParentTextStyles (element, passProps, styles = []) {
+    const { attribs, name } = element;
+    const { classesStyles, tagsStyles, defaultTextStyles } = passProps;
+
+    // Construct every style for this node
+    const HTMLAttribsStyles = attribs && attribs.style ? cssStringToRNStyle(attribs.style, STYLESETS.TEXT, passProps) : {};
+    const classStyles = _getElementClassStyles(attribs, classesStyles);
+    const userTagStyles = tagsStyles[name];
+    const defaultTagStyles = defaultTextStyles[name];
+
+    // Merge those according to their priority level
+    const mergedStyles = {
+        ...defaultTagStyles,
+        ...userTagStyles,
+        ...classStyles,
+        ...HTMLAttribsStyles
+    };
+
+    styles.push(mergedStyles);
+
+    if (element.parent) {
+        // Keep looping recursively if this node has parents
+        return _recursivelyComputeParentTextStyles(element.parent, passProps, styles);
+    } else {
+        return styles;
+    }
+}
+
+/**
  * Creates a set of style from an array of classes asosciated to a node.
  * @export
  * @param {any} htmlAttribs
@@ -101,7 +161,7 @@ export function _getElementCSSClasses (htmlAttribs) {
  * @param {object} { parentTag, emSize, ignoredStyles }
  * @returns {object}
  */
-function cssToRNStyle (css, styleset, { parentTag, emSize, ptSize, ignoredStyles, allowedStyles }) {
+function cssToRNStyle (css, styleset, { emSize, ptSize, ignoredStyles, allowedStyles }) {
     const styleProps = stylePropTypes[styleset];
     return Object.keys(css)
         .filter((key) => allowedStyles ? allowedStyles.indexOf(key) !== -1 : true)


### PR DESCRIPTION
## Features

* Add `renderersProps` prop. This lets you pass a set of props to your custom renderers, allowing you to style them furthermore without duplicating the renderers code. For instance, if you create a `blockquote` custom renderer, you can alter its color depending on the data you're rendering.

Example :

```javascript
<HTML html={...} renderers={renderers} renderersProps={{ color: 'blue' } />
<HTML html={...} renderers={renderers} renderersProps={{ color: 'red' } />

const renderers = {
    blockquote: (htmlAttribs, children, convertedCSSStyles, passProps) => {
        const { renderersProps } = passProps;
        // rendersProps : { color: blue/red }

        return ...
    }
}
```

## Rework

* The logic that applies text styling has been rewritten from scratch. The previous implementation had a lot of flaws that were hard to debug. This should be a much needed improvement addressing some of the oldest issues of this plugin. [The new algorithm is explained here](https://github.com/archriss/react-native-render-html/issues/102#issuecomment-375594792). Closes #119, closes #102 

⚠️ *Although this shouldn't be a breaking change, your current rendering might be taking into account the previous buggy implementation. Upgrading to `3.10.0` might break some of your advanced text styling, just because it's now working as it should have from the beginning.* ⚠️ 

## Bugfixes

* Is some cases, text nodes used to be wrapped in additional `<p>` tags. This could have unintended style effects. Let's now wrap them in a new custom tag that behaves like an inline tag, but without styling : `textwrapper`