### PR TITLE
Removed not used dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "buffer": "^4.5.1",
     "events": "^1.1.0",
     "html-entities": "^1.2.0",
-    "htmlparser2": "^3.9.0",
-    "stream": "0.0.2"
+    "htmlparser2": "^3.9.0"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.10",


### PR DESCRIPTION
Stream dependency caused issues when used together with [node-libs-browser](https://github.com/webpack/node-libs-browser) stream library.