### PR TITLE
Fix HTMLImage calling setState in Image.getSize callback after component unmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-render-html",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "author": "Archriss",
   "license": "BSD-2-Clause",
   "repository": "https://github.com/archriss/react-native-render-html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-render-html",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "author": "Archriss",
   "license": "BSD-2-Clause",
   "repository": "https://github.com/archriss/react-native-render-html",

--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -81,20 +81,22 @@ export default class HTMLImage extends PureComponent {
             });
         }
         // Fetch image dimensions only if they aren't supplied or if with or height is missing
-        Image.getSize(
-            source.uri,
-            (originalWidth, originalHeight) => {
-                if (!imagesMaxWidth) {
-                    return this.setState({ width: originalWidth, height: originalHeight });
+        setTimeout(() => {
+            Image.getSize(
+                source.uri,
+                (originalWidth, originalHeight) => {
+                    if (!imagesMaxWidth) {
+                        return this.setState({ width: originalWidth, height: originalHeight });
+                    }
+                    const optimalWidth = imagesMaxWidth <= originalWidth ? imagesMaxWidth : originalWidth;
+                    const optimalHeight = (optimalWidth * originalHeight) / originalWidth;
+                    this.setState({ width: optimalWidth, height: optimalHeight, error: false });
+                },
+                () => {
+                    this.setState({ error: true });
                 }
-                const optimalWidth = imagesMaxWidth <= originalWidth ? imagesMaxWidth : originalWidth;
-                const optimalHeight = (optimalWidth * originalHeight) / originalWidth;
-                this.setState({ width: optimalWidth, height: optimalHeight, error: false });
-            },
-            () => {
-                this.setState({ error: true });
-            }
-        );
+            );
+        }, 0);
     }
 
     validImage (source, style, props = {}) {

--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -35,6 +35,10 @@ export default class HTMLImage extends PureComponent {
         this.getImageSize();
     }
 
+    componentWillUnmount() {
+        this.unmounted = true;
+    }
+
     componentWillReceiveProps (nextProps) {
         this.getImageSize(nextProps);
     }
@@ -81,22 +85,23 @@ export default class HTMLImage extends PureComponent {
             });
         }
         // Fetch image dimensions only if they aren't supplied or if with or height is missing
-        setTimeout(() => {
-            Image.getSize(
-                source.uri,
-                (originalWidth, originalHeight) => {
-                    if (!imagesMaxWidth) {
-                        return this.setState({ width: originalWidth, height: originalHeight });
-                    }
-                    const optimalWidth = imagesMaxWidth <= originalWidth ? imagesMaxWidth : originalWidth;
-                    const optimalHeight = (optimalWidth * originalHeight) / originalWidth;
-                    this.setState({ width: optimalWidth, height: optimalHeight, error: false });
-                },
-                () => {
-                    this.setState({ error: true });
+
+        Image.getSize(
+            source.uri,
+            (originalWidth, originalHeight) => {
+                if(this.unmounted) return;
+                if (!imagesMaxWidth) {
+                    return this.setState({ width: originalWidth, height: originalHeight });
                 }
-            );
-        }, 0);
+                const optimalWidth = imagesMaxWidth <= originalWidth ? imagesMaxWidth : originalWidth;
+                const optimalHeight = (optimalWidth * originalHeight) / originalWidth;
+                this.setState({ width: optimalWidth, height: optimalHeight, error: false });
+            },
+            () => {
+                if(this.unmounted) return;
+                this.setState({ error: true });
+            }
+        );
     }
 
     validImage (source, style, props = {}) {

--- a/src/HTMLStyles.js
+++ b/src/HTMLStyles.js
@@ -191,6 +191,11 @@ function cssToRNStyle (css, styleset, { emSize, ptSize, ignoredStyles, allowedSt
                         return undefined;
                     }
                     value = value.replace('!important', '');
+
+                    if (value.search('calc') !== -1) {
+                        return [key, '100%'];
+                    }
+
                     // See if we can use the percentage directly
                     if (value.search('%') !== -1 && PERC_SUPPORTED_STYLES.indexOf(key) !== -1) {
                         return [key, value];


### PR DESCRIPTION
This is a fix for https://github.com/archriss/react-native-render-html/issues/183. Just setting a property `unmounted` on `componentWillUnmount` and checking if it's true inside `Image.getSize` callback and if it is, then it exists immediately without executing `setState`.