### PR TITLE
fix remoteErrorView render

### DIFF
--- a/src/HTML.js
+++ b/src/HTML.js
@@ -471,8 +471,8 @@ export default class HTML extends PureComponent {
     render () {
         const { customWrapper, remoteLoadingView, remoteErrorView } = this.props;
         const { RNNodes, loadingRemoteURL, errorLoadingRemoteURL } = this.state;
-        if (!RNNodes && !loadingRemoteURL) {
-            return false;
+        if (!RNNodes && !loadingRemoteURL && !errorLoadingRemoteURL) {
+            return null;
         } else if (loadingRemoteURL) {
             return remoteLoadingView ?
                 remoteLoadingView(this.props, this.state) :


### PR DESCRIPTION
After catching error as result of fetching uri we must to render error component.
But we never render it because  we always get condition:
https://github.com/archriss/react-native-render-html/blob/master/src/HTML.js#L474
To fix this we need to add an extra check.
