### PR TITLE
v4.1.0

### DIFF
--- a/Demo/package.json
+++ b/Demo/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "^16.6.3",
     "react-native": "^0.58.3",
-    "react-native-render-html": "4.0.0"
+    "react-native-render-html": "4.1.0"
   },
   "devDependencies": {
     "babel-core": "^7.0.0-bridge.0",

--- a/README.md
+++ b/README.md
@@ -16,24 +16,24 @@ An iOS/Android pure javascript react-native component that renders your HTML int
 ## Table of contents
 
 - [react-native-render-html](#react-native-render-html)
-    - [Table of contents](#table-of-contents)
-    - [Install](#install)
-    - [Basic usage](#basic-usage)
-    - [Props](#props)
-    - [Demo](#demo)
-    - [Creating custom renderers](#creating-custom-renderers)
-        - [Custom HTML tags](#custom-html-tags)
-        - [Making your custom component block or inline](#making-your-custom-component-block-or-inline)
-        - [Lists prefixes](#lists-prefixes)
-    - [Styling](#styling)
-    - [Images](#images)
-    - [Altering content](#altering-content)
-        - [alterData](#alterdata)
-        - [alterChildren](#alterchildren)
-        - [alterNode](#alternode)
-        - [onParsed](#onparsed)
-    - [Ignoring HTML content](#ignoring-html-content)
-    - [Useful functions](#useful-functions)
+  - [Table of contents](#table-of-contents)
+  - [Install](#install)
+  - [Basic usage](#basic-usage)
+  - [Props](#props)
+  - [Demo](#demo)
+  - [Creating custom renderers](#creating-custom-renderers)
+    - [Custom HTML tags](#custom-html-tags)
+    - [Making your custom component block or inline](#making-your-custom-component-block-or-inline)
+    - [Lists prefixes](#lists-prefixes)
+  - [Styling](#styling)
+  - [Images](#images)
+  - [Altering content](#altering-content)
+    - [alterData](#alterdata)
+    - [alterChildren](#alterchildren)
+    - [alterNode](#alternode)
+    - [onParsed](#onparsed)
+  - [Ignoring HTML content](#ignoring-html-content)
+  - [Useful functions](#useful-functions)
 
 ## Install
 
@@ -88,6 +88,7 @@ Prop | Description | Type | Required/Default
 `emSize` | The default value in pixels for `1em` | `number` | `14`
 `ptSize` | The default value in pixels for `1pt` | `number` | `1.3`
 `baseFontStyle` | The default style applied to `<Text>` components | `object` | `{ fontSize: 14 }`
+`allowFontScaling` | Specifies whether fonts should scale to respect Text Size accessibility settings | `boolean` | `true`
 `textSelectable` | Allow all texts to be selected | `boolean` | `false`
 `alterData` | Target some specific texts and change their content, see [altering content](#altering-content) | `function` | Optional
 `alterChildren` | Target some specific nested children and change them, see [altering content](#altering-content) | `function` | Optional

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ renderers: {
 }
 ```
 
-Here, we have overriden the default `<br />` renderer and made it a blue line.
+Here, we have overriden the default `<hr />` renderer and made it a blue line.
 
 You can also create your own tags and use them in your HTML content :
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "buffer": "^4.5.1",
     "events": "^1.1.0",
     "html-entities": "^1.2.0",
-    "htmlparser2": "^3.9.0",
-    "stream": "0.0.2"
+    "htmlparser2": "^3.9.0"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-render-html",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": "Archriss",
   "license": "BSD-2-Clause",
   "repository": "https://github.com/archriss/react-native-render-html",

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -9,7 +9,8 @@ import {
     IGNORED_TAGS,
     TEXT_TAGS_IGNORING_ASSOCIATION,
     STYLESETS,
-    TextOnlyPropTypes
+    TextOnlyPropTypes,
+    PREFORMATTED_TAGS
 } from './HTMLUtils';
 import { generateDefaultBlockStyles, generateDefaultTextStyles } from './HTMLDefaultStyles';
 import htmlparser2 from 'htmlparser2';
@@ -274,10 +275,20 @@ export default class HTML extends PureComponent {
                     // This is blank, don't render an useless additional component
                     return false;
                 }
+
+                if (
+                    node.parent &&
+                    node.parent.name &&
+                    PREFORMATTED_TAGS.indexOf(node.parent.name) === -1
+                ) {
+                    // Remove line breaks in non-pre-formatted tags
+                    data = data.replace(/(\r\n|\n|\r)/gm, '');
+                }
+
                 // Text without tags, these can be mapped to the Text wrapper
                 return {
                     wrapper: 'Text',
-                    data: data.replace(/(\r\n|\n|\r)/gm, ''), // remove linebreaks
+                    data: data,
                     attribs: attribs || {},
                     parent,
                     parentTag: parent && parent.name,

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -46,7 +46,8 @@ export default class HTML extends PureComponent {
         ptSize: PropTypes.number.isRequired,
         baseFontStyle: PropTypes.object.isRequired,
         textSelectable: PropTypes.bool,
-        renderersProps: PropTypes.object
+        renderersProps: PropTypes.object,
+        allowFontScaling: PropTypes.bool
     }
 
     static defaultProps = {
@@ -62,7 +63,8 @@ export default class HTML extends PureComponent {
         baseFontStyle: { fontSize: 14 },
         tagsStyles: {},
         classesStyles: {},
-        textSelectable: false
+        textSelectable: false,
+        allowFontScaling: true
     }
 
     constructor (props) {
@@ -382,7 +384,18 @@ export default class HTML extends PureComponent {
      * @memberof HTML
      */
     renderRNElements (RNElements, parentWrapper = 'root', parentIndex = 0, props = this.props) {
-        const { tagsStyles, classesStyles, emSize, ptSize, ignoredStyles, allowedStyles, baseFontStyle } = props;
+        const {
+            allowFontScaling,
+            allowedStyles,
+            baseFontStyle,
+            classesStyles,
+            emSize,
+            ignoredStyles,
+            ptSize,
+            tagsStyles,
+            textSelectable
+        } = props;
+
         return RNElements && RNElements.length ? RNElements.map((element, index) => {
             const { attribs, data, tagName, parentTag, children, nodeIndex, wrapper } = element;
             const Wrapper = wrapper === 'Text' ? Text : View;
@@ -430,6 +443,7 @@ export default class HTML extends PureComponent {
             const classStyles = _getElementClassStyles(attribs, classesStyles);
             const textElement = data ?
                 <Text
+                  allowFontScaling={allowFontScaling}
                   style={computeTextStyles(
                       element,
                       {
@@ -457,7 +471,8 @@ export default class HTML extends PureComponent {
 
             const renderersProps = {};
             if (Wrapper === Text) {
-                renderersProps.selectable = this.props.textSelectable;
+                renderersProps.allowFontScaling = allowFontScaling;
+                renderersProps.selectable = textSelectable;
             }
             return (
                 <Wrapper key={key} style={style} {...renderersProps}>
@@ -469,7 +484,7 @@ export default class HTML extends PureComponent {
     }
 
     render () {
-        const { customWrapper, remoteLoadingView, remoteErrorView } = this.props;
+        const { allowFontScaling, customWrapper, remoteLoadingView, remoteErrorView } = this.props;
         const { RNNodes, loadingRemoteURL, errorLoadingRemoteURL } = this.state;
         if (!RNNodes && !loadingRemoteURL) {
             return false;
@@ -486,7 +501,7 @@ export default class HTML extends PureComponent {
                 remoteErrorView(this.props, this.state) :
                 (
                     <View style={{ flex: 1, alignItems: 'center' }}>
-                        <Text style={{ fontStyle: 'italic', fontSize: 16 }}>Could not load { this.props.uri }</Text>
+                        <Text allowFontScaling={allowFontScaling} style={{ fontStyle: 'italic', fontSize: 16 }}>Could not load { this.props.uri }</Text>
                     </View>
                 );
         }

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -486,8 +486,8 @@ export default class HTML extends PureComponent {
     render () {
         const { allowFontScaling, customWrapper, remoteLoadingView, remoteErrorView } = this.props;
         const { RNNodes, loadingRemoteURL, errorLoadingRemoteURL } = this.state;
-        if (!RNNodes && !loadingRemoteURL) {
-            return false;
+        if (!RNNodes && !loadingRemoteURL && !errorLoadingRemoteURL) {
+            return null;
         } else if (loadingRemoteURL) {
             return remoteLoadingView ?
                 remoteLoadingView(this.props, this.state) :

--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -33,6 +33,11 @@ export default class HTMLImage extends PureComponent {
 
     componentDidMount () {
         this.getImageSize();
+        this.mounted = true;
+    }
+
+    componentWillUnmount () {
+        this.mounted = false;
     }
 
     componentWillReceiveProps (nextProps) {
@@ -75,7 +80,7 @@ export default class HTMLImage extends PureComponent {
         const { styleWidth, styleHeight } = this.getDimensionsFromStyle(style, height, width);
 
         if (styleWidth && styleHeight) {
-            return this.setState({
+            return this.mounted && this.setState({
                 width: typeof styleWidth === 'string' && styleWidth.search('%') !== -1 ? styleWidth : parseInt(styleWidth, 10),
                 height: typeof styleHeight === 'string' && styleHeight.search('%') !== -1 ? styleHeight : parseInt(styleHeight, 10)
             });
@@ -85,14 +90,14 @@ export default class HTMLImage extends PureComponent {
             source.uri,
             (originalWidth, originalHeight) => {
                 if (!imagesMaxWidth) {
-                    return this.setState({ width: originalWidth, height: originalHeight });
+                    return this.mounted && this.setState({ width: originalWidth, height: originalHeight });
                 }
                 const optimalWidth = imagesMaxWidth <= originalWidth ? imagesMaxWidth : originalWidth;
                 const optimalHeight = (optimalWidth * originalHeight) / originalWidth;
-                this.setState({ width: optimalWidth, height: optimalHeight, error: false });
+                this.mounted && this.setState({ width: optimalWidth, height: optimalHeight, error: false });
             },
             () => {
-                this.setState({ error: true });
+                this.mounted && this.setState({ error: true });
             }
         );
     }

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity, Text, View, WebView, Dimensions } from 'react-native';
+import { TouchableOpacity, Text, View, WebView, Platform } from 'react-native';
 import { _constructStyles, _getElementClassStyles } from './HTMLStyles';
 import HTMLImage from './HTMLImage';
 
@@ -141,6 +141,16 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
 
     return (
         <WebView key={passProps.key} source={{ uri: htmlAttribs.src }} style={style} />
+    );
+}
+
+export function pre (htlmAttribs, children, convertedCSSStyles, passProps) {
+    return (
+        <Text
+          key={passProps.key}
+          style={{ fontFamily: Platform.OS === 'android' ? 'monospace' : 'Menlo' }}>
+            { children }
+        </Text>
     );
 }
 

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -63,7 +63,7 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
         passProps,
         styleSet: 'VIEW'
     });
-    const { rawChildren, nodeIndex, key, baseFontStyle, listsPrefixesRenderers } = passProps;
+    const { allowFontScaling, rawChildren, nodeIndex, key, baseFontStyle, listsPrefixesRenderers } = passProps;
     const baseFontSize = baseFontStyle.fontSize || 14;
 
     children = children && children.map((child, index) => {
@@ -93,7 +93,7 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
                 );
             } else if (rawChild.parentTag === 'ol') {
                 prefix = listsPrefixesRenderers && listsPrefixesRenderers.ol ? listsPrefixesRenderers.ol(...rendererArgs) : (
-                    <Text style={{ marginRight: 5, fontSize: baseFontSize }}>{ index + 1 })</Text>
+                    <Text allowFontScaling={allowFontScaling} style={{ marginRight: 5, fontSize: baseFontSize }}>{ index + 1 })</Text>
                 );
             }
         }
@@ -146,12 +146,18 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
 
 export function br (htlmAttribs, children, convertedCSSStyles, passProps) {
     return (
-        <Text style={{ height: 1.2 * passProps.emSize, flex: 1 }} key={passProps.key}>{"\n"}</Text>
+        <Text
+            allowFontScaling={passProps.allowFontScaling}
+            style={{ height: 1.2 * passProps.emSize, flex: 1 }}
+            key={passProps.key}
+        >
+            {"\n"}
+        </Text>
     );
 }
 
-export function textwrapper (htmlAttribs, children, convertedCSSStyles, { key }) {
+export function textwrapper (htmlAttribs, children, convertedCSSStyles, { allowFontScaling, key }) {
     return (
-        <Text key={key} style={convertedCSSStyles}>{ children }</Text>
+        <Text allowFontScaling={allowFontScaling} key={key} style={convertedCSSStyles}>{ children }</Text>
     );
 }

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -80,7 +80,7 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
         ];
 
         if (rawChild) {
-            if (rawChild.parentTag === 'ul') && rawChild.tagName === 'li' {
+            if (rawChild.parentTag === 'ul' && rawChild.tagName === 'li') {
                 prefix = listsPrefixesRenderers && listsPrefixesRenderers.ul ? listsPrefixesRenderers.ul(...rendererArgs) : (
                     <View style={{
                         marginRight: 10,

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -80,7 +80,7 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
         ];
 
         if (rawChild) {
-            if (rawChild.parentTag === 'ul') {
+            if (rawChild.parentTag === 'ul') && rawChild.tagName === 'li' {
                 prefix = listsPrefixesRenderers && listsPrefixesRenderers.ul ? listsPrefixesRenderers.ul(...rendererArgs) : (
                     <View style={{
                         marginRight: 10,
@@ -91,7 +91,7 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
                         backgroundColor: 'black'
                     }} />
                 );
-            } else if (rawChild.parentTag === 'ol') {
+            } else if (rawChild.parentTag === 'ol' && rawChild.tagName === 'li') {
                 prefix = listsPrefixesRenderers && listsPrefixesRenderers.ol ? listsPrefixesRenderers.ol(...rendererArgs) : (
                     <Text allowFontScaling={allowFontScaling} style={{ marginRight: 5, fontSize: baseFontSize }}>{ index + 1 })</Text>
                 );

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -113,9 +113,6 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
 export const ol = ul;
 
 export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
-    if (!htmlAttribs.src) {
-        return false;
-    }
     const { staticContentMaxWidth, tagsStyles, classesStyles } = passProps;
 
     const tagStyleHeight = tagsStyles.iframe && tagsStyles.iframe.height;
@@ -139,8 +136,10 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
         additionalStyles: [{ height, width }]
     });
 
+    const source = htmlAttribs.srcdoc ? { html: htmlAttribs.srcdoc } : { uri: htmlAttribs.src };
+
     return (
-        <WebView key={passProps.key} source={{ uri: htmlAttribs.src }} style={style} />
+        <WebView key={passProps.key} source={source} style={style} />
     );
 }
 

--- a/src/HTMLUtils.js
+++ b/src/HTMLUtils.js
@@ -20,6 +20,9 @@ export const TEXT_TAGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'figcaption', 'p',
     'dfn', 'i', 'kbd', 'mark', 'q', 'rt', 's', 'samp', 'small', 'big', 'span', 'strong', 'sub', 'sup', 'time', 'u', 'var', 'wbr',
     'del', 'ins', 'blink', 'font', 'em', 'bold', 'br'];
 
+// Text in these tags should not be stripped from line breaks
+export const PREFORMATTED_TAGS = ['pre'];
+
 // These tags can either be mapped to View or Text wrappers, depending solely on their children
 export const MIXED_TAGS = ['a'];
 


### PR DESCRIPTION
## Features

* Add a default renderer for `<pre>`. This lets you display preformatted text such as code inside your content with a monospace font. #196
* Add `allowFontScaling` prop. #157 (thanks @amhinson !)
* Support `srcdoc` in `<iframe>` tags. #148 (thanks @charpeni !)

![](https://i.imgur.com/SAjVPDC.png)

## Bugfixes

* Properly display an error when fetching a remote content to display has failed. #199 (thanks @Alex123456780)
* Fix the rendering of nested lists, like `<ul>` inside `<ol>` #173 (thanks @muhamad-rizki)
* Don't update `HTMLImage`'s state after it's been unmounted. This prevents warnings during development. 4fca299
* Don't strip line breaks in `<pre>` tags #196 (thanks @henry40408 !)

## Miscellaneous

* Remove useless `stream` dependency from `package.json` #190 (thanks @ramuse !)
* Fix typo in the documentation #205 (thanks @ajmeese7 !)