### PR TITLE
corrects parentTagName to parentTag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Your renderers functions receive several arguments that will be very useful to m
 * `htmlAttribs`: attributes attached to the node, parsed in a react-native way
 * `children` : array with the children of the node
 * `convertedCSSStyles` : conversion of the `style` attribute from CSS to react-native's stylesheet
-* `passProps` : various useful information :  your `renderersProps`, `groupInfo`, `parentTagName`, `parentIsText`...
+* `passProps` : various useful information :  your `renderersProps`, `groupInfo`, `parentTag`, `parentIsText`...
 
 ### Making your custom component block or inline
 


### PR DESCRIPTION
Just a small PR to correct some information in the readme - the key on `passProps` is `parentTag`, not `parentTagName`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/archriss/react-native-render-html/235)
<!-- Reviewable:end -->
