### PR TITLE
[5.x] Resize iframes with respect to its aspect ratio if the staticContentMaxWidth is set

### DIFF
--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -32,8 +32,8 @@ export default class HTMLImage extends PureComponent {
     }
 
     componentDidMount () {
-        this.getImageSize();
         this.mounted = true;
+        this.getImageSize();
     }
 
     componentWillUnmount () {
@@ -80,10 +80,22 @@ export default class HTMLImage extends PureComponent {
         const { styleWidth, styleHeight } = this.getDimensionsFromStyle(style, height, width);
 
         if (styleWidth && styleHeight) {
-            return this.mounted && this.setState({
-                width: typeof styleWidth === 'string' && styleWidth.search('%') !== -1 ? styleWidth : parseInt(styleWidth, 10),
-                height: typeof styleHeight === 'string' && styleHeight.search('%') !== -1 ? styleHeight : parseInt(styleHeight, 10)
-            });
+            const w = typeof styleWidth === 'string' && styleWidth.search('%') !== -1 ? styleWidth : parseInt(styleWidth, 10);
+            const h = typeof styleHeight === 'string' && styleHeight.search('%') !== -1 ? styleHeight : parseInt(styleHeight, 10);
+            
+            if(!imagesMaxWidth) {
+                return this.mounted && this.setState({
+                    width: w,
+                    height: h
+                });
+            } else {
+                const optimalWidth = imagesMaxWidth <= w ? imagesMaxWidth : w;
+                const optimalHeight = (optimalWidth * h) / w;
+                return this.mounted && this.setState({
+                    width: optimalWidth,
+                    height: optimalHeight
+                });
+            }
         }
         // Fetch image dimensions only if they aren't supplied or if with or height is missing
         Image.getSize(

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -126,15 +126,20 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
     const attrHeight = htmlAttribs.height ? parseInt(htmlAttribs.height) : false;
     const attrWidth = htmlAttribs.width ? parseInt(htmlAttribs.width) : false;
 
-    const height = attrHeight || classStyleHeight || tagStyleHeight || 200;
-    const width = attrWidth || classStyleWidth || tagStyleWidth || staticContentMaxWidth;
+    const iframeHeight = attrHeight || classStyleHeight || tagStyleHeight || 200;
+    const iframeWidth = attrWidth || classStyleWidth || tagStyleWidth;
+
+    let actualWidth = iframeWidth;
+    if(staticContentMaxWidth) {
+        actualWidth = (iframeHeight / iframeWidth) * staticContentMaxWidth;
+    } 
 
     const style = _constructStyles({
         tagName: 'iframe',
         htmlAttribs,
         passProps,
         styleSet: 'VIEW',
-        additionalStyles: [{ height, width }]
+        additionalStyles: [{ iframeHeight, actualWidth }]
     });
 
     const source = htmlAttribs.srcdoc ? { html: htmlAttribs.srcdoc } : { uri: htmlAttribs.src };

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -130,7 +130,7 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
     const iframeWidth = attrWidth || classStyleWidth || tagStyleWidth;
 
     let actualWidth = iframeWidth;
-    if(staticContentMaxWidth) {
+    if(staticContentMaxWidth && iframeWidth) {
         actualWidth = (iframeHeight / iframeWidth) * staticContentMaxWidth;
     } 
 

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -139,7 +139,7 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
         htmlAttribs,
         passProps,
         styleSet: 'VIEW',
-        additionalStyles: [{ iframeHeight, actualWidth }]
+        additionalStyles: [{ height: iframeHeight, width: actualWidth }]
     });
 
     const source = htmlAttribs.srcdoc ? { html: htmlAttribs.srcdoc } : { uri: htmlAttribs.src };

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -132,8 +132,8 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
     let actualWidth = iframeWidth;
     let actualHeight = iframeHeight;
     if(staticContentMaxWidth && iframeWidth) {
-        actualHeight = (iframeHeight / iframeWidth) * staticContentMaxWidth;
         actualWidth = Math.min(staticContentMaxWidth, iframeWidth);
+        actualHeight = (iframeHeight / iframeWidth) * actualWidth;
     } 
 
     const style = _constructStyles({

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -130,8 +130,10 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
     const iframeWidth = attrWidth || classStyleWidth || tagStyleWidth;
 
     let actualWidth = iframeWidth;
+    let actualHeight = iframeHeight;
     if(staticContentMaxWidth && iframeWidth) {
-        actualWidth = (iframeHeight / iframeWidth) * staticContentMaxWidth;
+        actualHeight = (iframeHeight / iframeWidth) * staticContentMaxWidth;
+        actualWidth = Math.min(staticContentMaxWidth, iframeWidth);
     } 
 
     const style = _constructStyles({
@@ -139,7 +141,7 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
         htmlAttribs,
         passProps,
         styleSet: 'VIEW',
-        additionalStyles: [{ height: iframeHeight, width: actualWidth }]
+        additionalStyles: [{ height: actualHeight, width: actualWidth }]
     });
 
     const source = htmlAttribs.srcdoc ? { html: htmlAttribs.srcdoc } : { uri: htmlAttribs.src };


### PR DESCRIPTION
StaticContentMaxWidth was only being used when all other sizing options failed and not available as an override for sizing. This PR makes sure it overrides the sizings and calculates the appropriate height according to the iframes requested aspect ratio.