### PR TITLE
webview from react-native-webview instead of react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "buffer": "^4.5.1",
     "events": "^1.1.0",
     "html-entities": "^1.2.0",
-    "htmlparser2": "^3.10.1"
+    "htmlparser2": "^3.10.1",
+    "react-native-webview": "^5.6.0"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.10",

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { TouchableOpacity, Text, View, WebView, Platform } from 'react-native';
+import { TouchableOpacity, Text, View, Platform } from 'react-native';
+import { WebView } from 'react-native-webview';
 import { _constructStyles, _getElementClassStyles } from './HTMLStyles';
 import HTMLImage from './HTMLImage';
 


### PR DESCRIPTION
WebView is moving to react-native-webview

https://facebook.github.io/react-native/docs/webview
> Warning Please use the react-native-community/react-native-webview fork of this component instead. To reduce the surface area of React Native, <WebView/> is going to be removed from the React Native core. For more information, please read The Slimmening proposal.