### PR TITLE
Get image size after marking component as mounted

### DIFF
--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -32,8 +32,8 @@ export default class HTMLImage extends PureComponent {
     }
 
     componentDidMount () {
-        this.getImageSize();
         this.mounted = true;
+        this.getImageSize();
     }
 
     componentWillUnmount () {


### PR DESCRIPTION
Image size was not set to state on initial render. Fixed it by adjusting call order.