### PR TITLE
Display attribute restricted to "flex" and "none"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "buffer": "^4.5.1",
     "events": "^1.1.0",
     "html-entities": "^1.2.0",
-    "htmlparser2": "^3.10.1",
+    "htmlparser2": "^3.10.1"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.10",

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "events": "^1.1.0",
     "html-entities": "^1.2.0",
     "htmlparser2": "^3.10.1",
-    "react-native-webview": "^5.6.0"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.10",
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-webview": "*"
   },
   "devDependencies": {
     "babel-eslint": "8.2.2",

--- a/src/HTMLStyles.js
+++ b/src/HTMLStyles.js
@@ -208,6 +208,9 @@ function cssToRNStyle (css, styleset, { emSize, ptSize, ignoredStyles, allowedSt
                 if (key === 'fontSize') {
                     return mapAbsoluteFontSize(key, value);
                 }
+                if (key === 'display' && ['flex', 'none'].indexOf(value) === -1) {
+                    return [key, 'flex'];
+                }
             }
             return [key, value];
         })


### PR DESCRIPTION
If an element has a display attribute that is not `flex` or `none` it will give an error (e.g. [issue 257](https://github.com/archriss/react-native-render-html/issues/257)).

This PR introduces a validation to only allow those 2 values and default to `flex` if otherwise.

Thanks for the amazing library!