### PR TITLE
[5.x] Made WebView an optional dependency which can be passed as a prop to <HTML> to support iframes

### DIFF
--- a/Demo/src/HTMLDemo.js
+++ b/Demo/src/HTMLDemo.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { View, Text, ScrollView, TouchableOpacity, Dimensions, Linking } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity, Dimensions, Linking, WebView } from 'react-native';
 import HTML from 'react-native-render-html';
 import EXAMPLES, * as snippets from './snippets';
 import styles from './styles';
@@ -10,6 +10,7 @@ const CUSTOM_RENDERERS = {};
 const DEFAULT_PROPS = {
     htmlStyles: CUSTOM_STYLES,
     renderers: CUSTOM_RENDERERS,
+    WebView: WebView,
     imagesMaxWidth: IMAGES_MAX_WIDTH,
     onLinkPress: (evt, href) => { Linking.openURL(href); },
     debug: true

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An iOS/Android pure javascript react-native component that renders your HTML int
     - [Lists prefixes](#lists-prefixes)
   - [Styling](#styling)
   - [Images](#images)
+  - [IFrames](#iframes)
   - [Altering content](#altering-content)
     - [alterData](#alterdata)
     - [alterChildren](#alterchildren)
@@ -70,6 +71,7 @@ Prop | Description | Type | Required/Default
 ------ | ------ | ------ | ------
 `renderers` | Your [custom renderers](#creating-custom-renderers) | `object` | Optional, some default ones are supplied (`<a>`, `<img>`...)
 `renderersProps` | Set of props accessible into your [custom renderers](#creating-custom-renderers) in `passProps` (4th argument) | `object` | Optional
+`WebView`| Sets the WebView component to use when rendering `<iframe>` elements | `Component` | Optional
 `html` | HTML string to parse and render | `string` | Required
 `uri` | *(experimental)* remote website to parse and render | `string` | Optional
 `decodeEntities` | Decode HTML entities of your content | `bool` | Optional, defaults to `true`
@@ -210,6 +212,27 @@ Before their dimensions have been properly retrieved, images will temporarily be
 Images with broken links will render an empty square with a thin border, similar to what safari renders in a webview.
 
 Please note that all of these behaviors are implemented in the default `<img>` renderer. If you want to provide your own `<img>` renderer, you'll have to make this happen by yourself. You can use the `img` function in `HTMLRenderers.js` as a starting point.
+
+## IFrames
+
+In order to render `<iframe>` elements, a WebView component needs to be imported and passed to the `<HTML>` element.
+
+```javascript
+import React from 'react';
+import HTML from 'react-native-render-html';
+import { WebView } from 'react-native-webview';
+
+const htmlContent = `
+    <p>Yes you read that right, those damn iframes can render with this plugin.</p>
+    <p>Check this out</p>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/ZZ5LpwO-An4" frameborder="0" allowfullscreen></iframe>
+    <p style="text-align:center;"><em>We've just rendered a meme</em></p>
+`;
+
+export default IFrameDemo = () => (
+    <HTML html={htmlContent} WebView={WebView}/>
+);
+```
 
 ## Altering content
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "buffer": "^4.5.1",
     "events": "^1.1.0",
     "html-entities": "^1.2.0",
-    "htmlparser2": "^3.10.1",
-    "react-native-webview": "^5.6.0"
+    "htmlparser2": "^3.10.1"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.10",

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -48,7 +48,8 @@ export default class HTML extends PureComponent {
         baseFontStyle: PropTypes.object.isRequired,
         textSelectable: PropTypes.bool,
         renderersProps: PropTypes.object,
-        allowFontScaling: PropTypes.bool
+        allowFontScaling: PropTypes.bool,
+        WebView: PropTypes.elementType
     }
 
     static defaultProps = {

--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { TouchableOpacity, Text, View, Platform } from 'react-native';
-import { WebView } from 'react-native-webview';
 import { _constructStyles, _getElementClassStyles } from './HTMLStyles';
 import HTMLImage from './HTMLImage';
 
@@ -114,7 +113,7 @@ export function ul (htmlAttribs, children, convertedCSSStyles, passProps = {}) {
 export const ol = ul;
 
 export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
-    const { staticContentMaxWidth, tagsStyles, classesStyles } = passProps;
+    const { staticContentMaxWidth, tagsStyles, classesStyles, WebView } = passProps;
 
     const tagStyleHeight = tagsStyles.iframe && tagsStyles.iframe.height;
     const tagStyleWidth = tagsStyles.iframe && tagsStyles.iframe.width;
@@ -138,6 +137,11 @@ export function iframe (htmlAttribs, children, convertedCSSStyles, passProps) {
     });
 
     const source = htmlAttribs.srcdoc ? { html: htmlAttribs.srcdoc } : { uri: htmlAttribs.src };
+
+    if (!WebView) {
+        console.warn('react-native-render-html', 'Unable to render <iframe>, please specify the `WebView` prop in <HTML>')
+        return null;
+    }
 
     return (
         <WebView key={passProps.key} source={source} style={style} />


### PR DESCRIPTION
Hi 👋

This PR makes the WebView component optional, so you can choose to include it or not. I'll try to explain my reasoning about why `WebView` is preferably optional for this package.

- As of RN60s auto-linking feature, any native dependencies are automatically linked into your project, *even if you aren't using them*. This was true for the `react-native-webview` component, which is installed when installing `react-native-render-html`. Linking packages unnecessary creates a problem as it often requires additional OS permissions or usage strings. It may cause your deploy to the App or Play store to fail. And obviously it also increases your binary size.
- `react-native-render-html` is a great way to render rich-content without requiring something heavy like a webview. It is this aspect which makes this library so damn useful and appealing.
- Because of the dependency on `react-native-webview`, this project becomes less compatible with older react-native versions, as well as requires more maintenance to keep the `webview` dependency up to date (there is already 4 PRs concerning webview-package updates).

I therefore suggest an opt-in approach, where people that are using `iframe`s can specify the `WebView` component that shall be used. The iframe-renderer then takes the WebView component and renders the content. When no WebView is specified to `<HTML>`, but a iframe is renderered nonetheless, a warning is written to the console (`Unable to render <iframe>, please specify the WebView prop in <HTML>`).

For the latest react-native versions you would then use it like this (**when you need iframes**):

```jsx
import { WebView } from 'react-native-webview`;

export default () => (
  <HTML ... WebView={WebView} />
);
```

And for older react-native versions you import WebView from react-native itself:

```js
import { WebView } from 'react-native`;
```

And obviously, if you don't use iframes, then just leave it out:

```jsx
export default () => (
  <HTML ... />
);
```

Cheers and thank you for this library!
