### PR TITLE
renamed depricated lifecycle names

### DIFF
--- a/src/HTML.js
+++ b/src/HTML.js
@@ -77,7 +77,7 @@ export default class HTML extends PureComponent {
         };
     }
 
-    componentWillMount () {
+    UNSAFE_componentWillMount () {
         this.generateDefaultStyles();
     }
 
@@ -85,7 +85,7 @@ export default class HTML extends PureComponent {
         this.registerDOM();
     }
 
-    componentWillReceiveProps (nextProps) {
+    UNSAFE_componentWillReceiveProps (nextProps) {
         const { html, uri, renderers } = this.props;
 
         this.generateDefaultStyles(nextProps.baseFontStyle);


### PR DESCRIPTION
renamed lifecycle to suppress yellowbox warning UNSAFE_componentWillMount, UNSAFE_componentWillReceiveProps, and UNSAFE_componentWillUpdate