### PR TITLE
Add prop to recognize self-closing tags (htmlparser now supports)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "buffer": "^4.5.1",
     "events": "^1.1.0",
     "html-entities": "^1.2.0",
-    "htmlparser2": "^3.10.1",
-    "react-native-webview": "^5.6.0"
+    "htmlparser2": "^4.1.0"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.10",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "peerDependencies": {
     "prop-types": ">=15.5.10",
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-webview": "*"
   },
   "devDependencies": {
     "babel-eslint": "8.2.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "buffer": "^4.5.1",
     "events": "^1.1.0",
     "html-entities": "^1.2.0",
-    "htmlparser2": "^4.1.0"
+    "htmlparser2": "^4.0.0"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.10",

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -49,7 +49,7 @@ export default class HTML extends PureComponent {
         textSelectable: PropTypes.bool,
         renderersProps: PropTypes.object,
         allowFontScaling: PropTypes.bool,
-        recognizeSelfClosing: PropTypes.bool
+        recognizeSelfClosingTags: PropTypes.bool
     }
 
     static defaultProps = {
@@ -67,7 +67,7 @@ export default class HTML extends PureComponent {
         classesStyles: {},
         textSelectable: false,
         allowFontScaling: true,
-        recognizeSelfClosing: false,
+        recognizeSelfClosingTags: false,
     }
 
     constructor (props) {
@@ -136,7 +136,7 @@ export default class HTML extends PureComponent {
     }
 
     parseDOM (dom, props = this.props) {
-        const { decodeEntities, debug, onParsed, recognizeSelfClosing } = this.props;
+        const { decodeEntities, debug, onParsed, recognizeSelfClosingTags } = this.props;
         const parser = new htmlparser2.Parser(
             new htmlparser2.DomHandler((_err, dom) => {
                 let RNElements = this.mapDOMNodesTORNElements(dom, false, props);
@@ -152,7 +152,7 @@ export default class HTML extends PureComponent {
                     console.log('RNElements from render-html', RNElements);
                 }
             }),
-            { decodeEntities: decodeEntities, recognizeSelfClosing: recognizeSelfClosing }
+            { decodeEntities: decodeEntities, recognizeSelfClosingTags: recognizeSelfClosingTags }
         );
         parser.write(dom);
         parser.done();

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -137,8 +137,8 @@ export default class HTML extends PureComponent {
 
     parseDOM (dom, props = this.props) {
         const { decodeEntities, debug, onParsed, recognizeSelfClosingTags } = this.props;
-        const parser = new htmlparser2.Parser(
-            new htmlparser2.DomHandler((_err, dom) => {
+        const parser = new Parser(
+            new DomHandler((_err, dom) => {
                 let RNElements = this.mapDOMNodesTORNElements(dom, false, props);
                 if (onParsed) {
                     const alteredRNElements = onParsed(dom, RNElements);

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -136,7 +136,7 @@ export default class HTML extends PureComponent {
     }
 
     parseDOM (dom, props = this.props) {
-        const { decodeEntities, debug, onParsed } = this.props;
+        const { decodeEntities, debug, onParsed, recognizeSelfClosing } = this.props;
         const parser = new htmlparser2.Parser(
             new htmlparser2.DomHandler((_err, dom) => {
                 let RNElements = this.mapDOMNodesTORNElements(dom, false, props);

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -48,7 +48,8 @@ export default class HTML extends PureComponent {
         baseFontStyle: PropTypes.object.isRequired,
         textSelectable: PropTypes.bool,
         renderersProps: PropTypes.object,
-        allowFontScaling: PropTypes.bool
+        allowFontScaling: PropTypes.bool,
+        recognizeSelfClosing: PropTypes.bool
     }
 
     static defaultProps = {
@@ -65,7 +66,8 @@ export default class HTML extends PureComponent {
         tagsStyles: {},
         classesStyles: {},
         textSelectable: false,
-        allowFontScaling: true
+        allowFontScaling: true,
+        recognizeSelfClosing: false,
     }
 
     constructor (props) {
@@ -150,7 +152,7 @@ export default class HTML extends PureComponent {
                     console.log('RNElements from render-html', RNElements);
                 }
             }),
-            { decodeEntities: decodeEntities }
+            { decodeEntities: decodeEntities, recognizeSelfClosing: recognizeSelfClosing }
         );
         parser.write(dom);
         parser.done();


### PR DESCRIPTION
Last time this was discussed ( https://github.com/archriss/react-native-render-html/issues/142 ), it looked like htmlparser didn't support self-closing tags...but it does now, per their documentation here --> https://github.com/fb55/htmlparser2/wiki/Parser-options



I've tested this internally and it appears to work fine.

I've left the default prop as false to not change the current behavior, but it could be true. That's more of a package maintainer decision ;-).
