### PR TITLE
Fix crashes with <iframe> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ An iOS/Android pure javascript react-native component that renders your HTML int
 
 `npm install react-native-render-html --save` or `yarn add react-native-render-html`
 
+Then, you must install and link [react-native-webview](https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.md) packet to you project
+
 ## Basic usage
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "buffer": "^4.5.1",
     "events": "^1.1.0",
     "html-entities": "^1.2.0",
-    "htmlparser2": "^3.10.1",
-    "react-native-webview": "^5.6.0"
+    "htmlparser2": "^4.0.0"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.10",
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-webview": "*"
   },
   "devDependencies": {
     "babel-eslint": "8.2.2",

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -13,7 +13,7 @@ import {
     PREFORMATTED_TAGS
 } from './HTMLUtils';
 import { generateDefaultBlockStyles, generateDefaultTextStyles } from './HTMLDefaultStyles';
-import htmlparser2 from 'htmlparser2';
+import { DomHandler, Parser } from 'htmlparser2';
 import * as HTMLRenderers from './HTMLRenderers';
 
 export default class HTML extends PureComponent {
@@ -135,8 +135,8 @@ export default class HTML extends PureComponent {
 
     parseDOM (dom, props = this.props) {
         const { decodeEntities, debug, onParsed } = this.props;
-        const parser = new htmlparser2.Parser(
-            new htmlparser2.DomHandler((_err, dom) => {
+        const parser = new Parser(
+            new DomHandler((_err, dom) => {
                 let RNElements = this.mapDOMNodesTORNElements(dom, false, props);
                 if (onParsed) {
                     const alteredRNElements = onParsed(dom, RNElements);


### PR DESCRIPTION
If you have <iframe> tag in your html content htmlparser2 v3.10.1 tries to use Webview from 'react-native' for render it and crash
Minimum example of the content on which the error occurs
`const content = "<iframe width="640" height="360" src="https://www.youtube.com/embed/iwKAE3rLGoQ?&wmode=opaque" frameborder="0" allowfullscreen="" class="fr-draggable"></iframe>"`

This PR fix crashes.
- update 'htmlparser2' dependency to v4.0.0
- small changes for correct work with new htmlparser2 version
- move 'react-native-webview' dependency to 'peerDependencies' section, because 'react-native-webview' must be linked before using
- add note about 'react-native-webview' dependency to readme.md file