### PR TITLE
fix: added fallback in case PropTypes are not exported

### DIFF
--- a/src/HTML.js
+++ b/src/HTML.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { View, Text, ViewPropTypes, ActivityIndicator, Dimensions } from 'react-native';
+import { View, Text, ActivityIndicator, Dimensions } from 'react-native';
 import { cssStringToRNStyle, _getElementClassStyles, cssStringToObject, cssObjectToString, computeTextStyles } from './HTMLStyles';
 import {
     BLOCK_TAGS,
@@ -33,7 +33,7 @@ export default class HTML extends PureComponent {
         uri: PropTypes.string,
         tagsStyles: PropTypes.object,
         classesStyles: PropTypes.object,
-        containerStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
+        containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
         customWrapper: PropTypes.func,
         onLinkPress: PropTypes.func,
         onParsed: PropTypes.func,

--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -16,7 +16,7 @@ export default class HTMLImage extends PureComponent {
         alt: PropTypes.string,
         height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        style: Image.propTypes.style,
+        style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
         imagesMaxWidth: PropTypes.number,
         imagesInitialDimensions: PropTypes.shape({
             width: PropTypes.number,


### PR DESCRIPTION
New versions of RN will remove propType exports.
This PR is opened in order to align with that.