### PR TITLE
[5.x] Added textProps prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ Prop | Description | Type | Required/Default
 `emSize` | The default value in pixels for `1em` | `number` | `14`
 `ptSize` | The default value in pixels for `1pt` | `number` | `1.3`
 `baseFontStyle` | The default style applied to `<Text>` components | `object` | `{ fontSize: 14 }`
-`allowFontScaling` | Specifies whether fonts should scale to respect Text Size accessibility settings | `boolean` | `true`
-`textSelectable` | Allow all texts to be selected | `boolean` | `false`
+`textWrapperProps` | Object with props, that would be applyed to text wrapper. For example `{allowFontScaling: 'false'}` | `object` | `{}`
 `alterData` | Target some specific texts and change their content, see [altering content](#altering-content) | `function` | Optional
 `alterChildren` | Target some specific nested children and change them, see [altering content](#altering-content) | `function` | Optional
 `alterNode` | Target a specific node and change it, see [altering content](#altering-content) | `function` | Optional

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -66,7 +66,7 @@ export default class HTML extends PureComponent {
         textWrapperProps: {},
     }
 
-    constructor(props) {
+    constructor (props) {
         super(props);
         this.state = {};
         this.renderers = {
@@ -77,7 +77,7 @@ export default class HTML extends PureComponent {
         this.generateDefaultStyles(props.baseFontStyle);
     }
 
-    componentDidMount() {
+    componentDidMount () {
         this.registerDOM();
     }
 
@@ -98,7 +98,7 @@ export default class HTML extends PureComponent {
         }
     }
 
-    async registerDOM(props = this.props, cb) {
+    async registerDOM (props = this.props, cb) {
         const { html, uri } = props;
         if (html) {
             this.setState({ dom: html, loadingRemoteURL: false, errorLoadingRemoteURL: false });
@@ -123,7 +123,7 @@ export default class HTML extends PureComponent {
         }
     }
 
-    parseDOM(dom, props = this.props) {
+    parseDOM (dom, props = this.props) {
         const { decodeEntities, debug, onParsed } = this.props;
         const parser = new Parser(
             new DomHandler((_err, dom) => {
@@ -146,7 +146,7 @@ export default class HTML extends PureComponent {
         parser.done();
     }
 
-    generateDefaultStyles(baseFontStyle = this.props.baseFontStyle) {
+    generateDefaultStyles (baseFontStyle = this.props.baseFontStyle) {
         this.defaultBlockStyles = generateDefaultBlockStyles(baseFontStyle.fontSize || 14);
         this.defaultTextStyles = generateDefaultTextStyles(baseFontStyle.fontSize || 14);
     }
@@ -157,7 +157,7 @@ export default class HTML extends PureComponent {
      * @returns {boolean}
      * @memberof HTML
      */
-    childrenNeedAView(children) {
+    childrenNeedAView (children) {
         for (let i = 0; i < children.length; i++) {
             if (children[i].wrapper === 'View') {
                 // If we find at least one View, it has to be nested in one
@@ -168,7 +168,7 @@ export default class HTML extends PureComponent {
         return false;
     }
 
-    wrapperHasTextChild(children) {
+    wrapperHasTextChild (children) {
         for (let i = 0; i < children.length; i++) {
             if (children[i].wrapper === 'Text') {
                 return true;
@@ -185,7 +185,7 @@ export default class HTML extends PureComponent {
      * @returns {array}
      * @memberof HTML
      */
-    associateRawTexts(children) {
+    associateRawTexts (children) {
         for (let i = 0; i < children.length; i++) {
             const child = children[i];
             if (
@@ -233,7 +233,7 @@ export default class HTML extends PureComponent {
      * @returns
      * @memberof HTML
      */
-    mapDOMNodesTORNElements(DOMNodes, parentTag = false, props = this.props) {
+    mapDOMNodesTORNElements (DOMNodes, parentTag = false, props = this.props) {
         const { ignoreNodesFunction, ignoredTags, alterNode, alterData, alterChildren, tagsStyles, classesStyles } = props;
         let RNElements = DOMNodes.map((node, nodeIndex) => {
             let { children, data } = node;
@@ -384,7 +384,7 @@ export default class HTML extends PureComponent {
      * @returns {array}
      * @memberof HTML
      */
-    renderRNElements(RNElements, parentWrapper = 'root', parentIndex = 0, props = this.props) {
+    renderRNElements (RNElements, parentWrapper = 'root', parentIndex = 0, props = this.props) {
         const {
             allowedStyles,
             baseFontStyle,
@@ -475,8 +475,8 @@ export default class HTML extends PureComponent {
             }
             return (
                 <Wrapper key={key} style={style} {...renderersProps}>
-                    {textElement}
-                    {childElements}
+                    { textElement }
+                    { childElements }
                 </Wrapper>
             );
         }) : false;
@@ -507,7 +507,7 @@ export default class HTML extends PureComponent {
 
         return customWrapper ? customWrapper(RNNodes) : (
             <View style={this.props.containerStyle || {}}>
-                {RNNodes}
+                { RNNodes }
             </View>
         );
     }

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -443,18 +443,18 @@ export default class HTML extends PureComponent {
             const classStyles = _getElementClassStyles(attribs, classesStyles);
             const textElement = data ?
                 <Text
-                    style={computeTextStyles(
-                        element,
-                        {
-                            defaultTextStyles: this.defaultTextStyles,
-                            tagsStyles,
-                            classesStyles,
-                            baseFontStyle,
-                            emSize,
-                            ptSize,
-                            ignoredStyles,
-                            allowedStyles
-                        })}
+                  style={computeTextStyles(
+                      element,
+                      {
+                          defaultTextStyles: this.defaultTextStyles,
+                          tagsStyles,
+                          classesStyles,
+                          baseFontStyle,
+                          emSize,
+                          ptSize,
+                          ignoredStyles,
+                          allowedStyles
+                      })}
                     {...textWrapperProps}
                 >
                     {data}
@@ -471,7 +471,7 @@ export default class HTML extends PureComponent {
 
             const renderersProps = {};
             if (Wrapper === Text) {
-                Object.keys(textWrapperProps).map(propName => { renderersProps[propName] = textWrapperProps[propName] });
+                renderersProps = textWrapperProps;
             }
             return (
                 <Wrapper key={key} style={style} {...renderersProps}>

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -443,18 +443,18 @@ export default class HTML extends PureComponent {
             const classStyles = _getElementClassStyles(attribs, classesStyles);
             const textElement = data ?
                 <Text
-                  style={computeTextStyles(
-                      element,
-                      {
-                          defaultTextStyles: this.defaultTextStyles,
-                          tagsStyles,
-                          classesStyles,
-                          baseFontStyle,
-                          emSize,
-                          ptSize,
-                          ignoredStyles,
-                          allowedStyles
-                      })}
+                    style={computeTextStyles(
+                        element,
+                        {
+                            defaultTextStyles: this.defaultTextStyles,
+                            tagsStyles,
+                            classesStyles,
+                            baseFontStyle,
+                            emSize,
+                            ptSize,
+                            ignoredStyles,
+                            allowedStyles
+                        })}
                     {...textWrapperProps}
                 >
                     {data}
@@ -471,7 +471,7 @@ export default class HTML extends PureComponent {
 
             const renderersProps = {};
             if (Wrapper === Text) {
-                renderersProps = textWrapperProps;
+                Object.keys(textWrapperProps).map(propName => { renderersProps[propName] = textWrapperProps[propName] });
             }
             return (
                 <Wrapper key={key} style={style} {...renderersProps}>

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -46,9 +46,8 @@ export default class HTML extends PureComponent {
         emSize: PropTypes.number.isRequired,
         ptSize: PropTypes.number.isRequired,
         baseFontStyle: PropTypes.object.isRequired,
-        textSelectable: PropTypes.bool,
         renderersProps: PropTypes.object,
-        allowFontScaling: PropTypes.bool
+        textWrapperProps: PropTypes.object,
     }
 
     static defaultProps = {
@@ -64,8 +63,7 @@ export default class HTML extends PureComponent {
         baseFontStyle: { fontSize: 14 },
         tagsStyles: {},
         classesStyles: {},
-        textSelectable: false,
-        allowFontScaling: true
+        textWrapperProps: {},
     }
 
     constructor (props) {
@@ -305,74 +303,74 @@ export default class HTML extends PureComponent {
                 return { wrapper: 'View', children, attribs, parent, tagName: name, parentTag };
             }
         })
-        .filter((parsedNode) => parsedNode !== false && parsedNode !== undefined) // remove useless nodes
-        .map((parsedNode, nodeIndex) => {
-            const { wrapper, children, attribs, tagName } = parsedNode;
-            const firstChild = children && children[0];
-            if (firstChild && children.length === 1) {
-                // Specific tweaks for wrappers with a single child
-                if ((attribs === firstChild.attribs || !firstChild.attribs) &&
-                    firstChild.wrapper === wrapper &&
-                    (tagName === firstChild.tagName || firstChild.tagName === 'rawtext')) {
-                    // If the only child of a node is using the same wrapper, merge them into one
-                    return {
-                        ...parsedNode,
-                        attribs: { ...attribs, ...firstChild.attribs },
-                        data: firstChild.data,
-                        children: [],
-                        tagName,
-                        nodeIndex
-                    };
-                }
-            }
-            return { ...parsedNode, nodeIndex };
-        })
-        .map((parsedNode, nodeIndex) => {
-            const { wrapper, attribs, tagName, children } = parsedNode;
-            if (wrapper === 'View' && attribs && this.wrapperHasTextChild(children)) {
-                // When encountering a View wrapper that has some styles and also Text children,
-                // let's filter out text-only styles and apply those to *all* Text children and
-                // remove them from the wrapper, mimicking browsers' behaviour better.
-                const wrapperStyles = {
-                    ...(tagsStyles[tagName] || {}),
-                    ...(_getElementClassStyles(attribs, classesStyles)),
-                    ...cssStringToObject(attribs.style || '')
-                };
-
-                let textChildrenInheritedStyles = {};
-                Object.keys(wrapperStyles).forEach((styleKey) => {
-                    // Extract text-only styles
-                    if (TextOnlyPropTypes.indexOf(styleKey) !== -1) {
-                        textChildrenInheritedStyles[styleKey] = wrapperStyles[styleKey];
-                        delete wrapperStyles[styleKey];
+            .filter((parsedNode) => parsedNode !== false && parsedNode !== undefined) // remove useless nodes
+            .map((parsedNode, nodeIndex) => {
+                const { wrapper, children, attribs, tagName } = parsedNode;
+                const firstChild = children && children[0];
+                if (firstChild && children.length === 1) {
+                    // Specific tweaks for wrappers with a single child
+                    if ((attribs === firstChild.attribs || !firstChild.attribs) &&
+                        firstChild.wrapper === wrapper &&
+                        (tagName === firstChild.tagName || firstChild.tagName === 'rawtext')) {
+                        // If the only child of a node is using the same wrapper, merge them into one
+                        return {
+                            ...parsedNode,
+                            attribs: { ...attribs, ...firstChild.attribs },
+                            data: firstChild.data,
+                            children: [],
+                            tagName,
+                            nodeIndex
+                        };
                     }
-                });
-                if (Object.keys(textChildrenInheritedStyles).length === 0) {
-                    // No style to apply to text children, avoid unecessary loops
-                    return parsedNode;
                 }
-                // Re-write wrapper's styles as a string
-                parsedNode.attribs.style = cssObjectToString(wrapperStyles);
-                for (let i = 0; i < children.length; i++) {
-                    const child = children[i];
-                    const { wrapper, attribs } = child;
+                return { ...parsedNode, nodeIndex };
+            })
+            .map((parsedNode, nodeIndex) => {
+                const { wrapper, attribs, tagName, children } = parsedNode;
+                if (wrapper === 'View' && attribs && this.wrapperHasTextChild(children)) {
+                    // When encountering a View wrapper that has some styles and also Text children,
+                    // let's filter out text-only styles and apply those to *all* Text children and
+                    // remove them from the wrapper, mimicking browsers' behaviour better.
+                    const wrapperStyles = {
+                        ...(tagsStyles[tagName] || {}),
+                        ...(_getElementClassStyles(attribs, classesStyles)),
+                        ...cssStringToObject(attribs.style || '')
+                    };
 
-                    if (wrapper === 'Text') {
-                        // Set (or merge) the inherited text styles extracted from the wrapper for
-                        // each Text child
-                        if (!attribs.style) {
-                            child.attribs.style = cssObjectToString(textChildrenInheritedStyles);
-                        } else {
-                            child.attribs.style = cssObjectToString({
-                                ...textChildrenInheritedStyles,
-                                ...cssStringToObject(child.attribs.style)
-                            });
+                    let textChildrenInheritedStyles = {};
+                    Object.keys(wrapperStyles).forEach((styleKey) => {
+                        // Extract text-only styles
+                        if (TextOnlyPropTypes.indexOf(styleKey) !== -1) {
+                            textChildrenInheritedStyles[styleKey] = wrapperStyles[styleKey];
+                            delete wrapperStyles[styleKey];
+                        }
+                    });
+                    if (Object.keys(textChildrenInheritedStyles).length === 0) {
+                        // No style to apply to text children, avoid unecessary loops
+                        return parsedNode;
+                    }
+                    // Re-write wrapper's styles as a string
+                    parsedNode.attribs.style = cssObjectToString(wrapperStyles);
+                    for (let i = 0; i < children.length; i++) {
+                        const child = children[i];
+                        const { wrapper, attribs } = child;
+
+                        if (wrapper === 'Text') {
+                            // Set (or merge) the inherited text styles extracted from the wrapper for
+                            // each Text child
+                            if (!attribs.style) {
+                                child.attribs.style = cssObjectToString(textChildrenInheritedStyles);
+                            } else {
+                                child.attribs.style = cssObjectToString({
+                                    ...textChildrenInheritedStyles,
+                                    ...cssStringToObject(child.attribs.style)
+                                });
+                            }
                         }
                     }
                 }
-            }
-            return parsedNode;
-        });
+                return parsedNode;
+            });
         return this.associateRawTexts(RNElements);
     }
 
@@ -388,7 +386,6 @@ export default class HTML extends PureComponent {
      */
     renderRNElements (RNElements, parentWrapper = 'root', parentIndex = 0, props = this.props) {
         const {
-            allowFontScaling,
             allowedStyles,
             baseFontStyle,
             classesStyles,
@@ -396,7 +393,7 @@ export default class HTML extends PureComponent {
             ignoredStyles,
             ptSize,
             tagsStyles,
-            textSelectable
+            textWrapperProps,
         } = props;
 
         return RNElements && RNElements.length ? RNElements.map((element, index) => {
@@ -446,21 +443,21 @@ export default class HTML extends PureComponent {
             const classStyles = _getElementClassStyles(attribs, classesStyles);
             const textElement = data ?
                 <Text
-                  allowFontScaling={allowFontScaling}
-                  style={computeTextStyles(
-                      element,
-                      {
-                          defaultTextStyles: this.defaultTextStyles,
-                          tagsStyles,
-                          classesStyles,
-                          baseFontStyle,
-                          emSize,
-                          ptSize,
-                          ignoredStyles,
-                          allowedStyles
-                      })}
+                    style={computeTextStyles(
+                        element,
+                        {
+                            defaultTextStyles: this.defaultTextStyles,
+                            tagsStyles,
+                            classesStyles,
+                            baseFontStyle,
+                            emSize,
+                            ptSize,
+                            ignoredStyles,
+                            allowedStyles
+                        })}
+                    {...textWrapperProps}
                 >
-                    { data }
+                    {data}
                 </Text> :
                 false;
 
@@ -470,12 +467,11 @@ export default class HTML extends PureComponent {
                 classStyles,
                 convertedCSSStyles
             ]
-            .filter((s) => s !== undefined);
+                .filter((s) => s !== undefined);
 
             const renderersProps = {};
             if (Wrapper === Text) {
-                renderersProps.allowFontScaling = allowFontScaling;
-                renderersProps.selectable = textSelectable;
+                Object.keys(textWrapperProps).map(propName => { renderersProps[propName] = textWrapperProps[propName] });
             }
             return (
                 <Wrapper key={key} style={style} {...renderersProps}>
@@ -487,7 +483,7 @@ export default class HTML extends PureComponent {
     }
 
     render () {
-        const { allowFontScaling, customWrapper, remoteLoadingView, remoteErrorView } = this.props;
+        const { customWrapper, remoteLoadingView, remoteErrorView, textWrapperProps } = this.props;
         const { RNNodes, loadingRemoteURL, errorLoadingRemoteURL } = this.state;
         if (!RNNodes && !loadingRemoteURL && !errorLoadingRemoteURL) {
             return null;
@@ -504,7 +500,7 @@ export default class HTML extends PureComponent {
                 remoteErrorView(this.props, this.state) :
                 (
                     <View style={{ flex: 1, alignItems: 'center' }}>
-                        <Text allowFontScaling={allowFontScaling} style={{ fontStyle: 'italic', fontSize: 16 }}>Could not load { this.props.uri }</Text>
+                        <Text style={{ fontStyle: 'italic', fontSize: 16 }} {...textWrapperProps}>Could not load {this.props.uri}</Text>
                     </View>
                 );
         }

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -303,74 +303,74 @@ export default class HTML extends PureComponent {
                 return { wrapper: 'View', children, attribs, parent, tagName: name, parentTag };
             }
         })
-            .filter((parsedNode) => parsedNode !== false && parsedNode !== undefined) // remove useless nodes
-            .map((parsedNode, nodeIndex) => {
-                const { wrapper, children, attribs, tagName } = parsedNode;
-                const firstChild = children && children[0];
-                if (firstChild && children.length === 1) {
-                    // Specific tweaks for wrappers with a single child
-                    if ((attribs === firstChild.attribs || !firstChild.attribs) &&
-                        firstChild.wrapper === wrapper &&
-                        (tagName === firstChild.tagName || firstChild.tagName === 'rawtext')) {
-                        // If the only child of a node is using the same wrapper, merge them into one
-                        return {
-                            ...parsedNode,
-                            attribs: { ...attribs, ...firstChild.attribs },
-                            data: firstChild.data,
-                            children: [],
-                            tagName,
-                            nodeIndex
-                        };
-                    }
-                }
-                return { ...parsedNode, nodeIndex };
-            })
-            .map((parsedNode, nodeIndex) => {
-                const { wrapper, attribs, tagName, children } = parsedNode;
-                if (wrapper === 'View' && attribs && this.wrapperHasTextChild(children)) {
-                    // When encountering a View wrapper that has some styles and also Text children,
-                    // let's filter out text-only styles and apply those to *all* Text children and
-                    // remove them from the wrapper, mimicking browsers' behaviour better.
-                    const wrapperStyles = {
-                        ...(tagsStyles[tagName] || {}),
-                        ...(_getElementClassStyles(attribs, classesStyles)),
-                        ...cssStringToObject(attribs.style || '')
+        .filter((parsedNode) => parsedNode !== false && parsedNode !== undefined) // remove useless nodes
+        .map((parsedNode, nodeIndex) => {
+            const { wrapper, children, attribs, tagName } = parsedNode;
+            const firstChild = children && children[0];
+            if (firstChild && children.length === 1) {
+                // Specific tweaks for wrappers with a single child
+                if ((attribs === firstChild.attribs || !firstChild.attribs) &&
+                    firstChild.wrapper === wrapper &&
+                    (tagName === firstChild.tagName || firstChild.tagName === 'rawtext')) {
+                    // If the only child of a node is using the same wrapper, merge them into one
+                    return {
+                        ...parsedNode,
+                        attribs: { ...attribs, ...firstChild.attribs },
+                        data: firstChild.data,
+                        children: [],
+                        tagName,
+                        nodeIndex
                     };
+                }
+            }
+            return { ...parsedNode, nodeIndex };
+        })
+        .map((parsedNode, nodeIndex) => {
+            const { wrapper, attribs, tagName, children } = parsedNode;
+            if (wrapper === 'View' && attribs && this.wrapperHasTextChild(children)) {
+                // When encountering a View wrapper that has some styles and also Text children,
+                // let's filter out text-only styles and apply those to *all* Text children and
+                // remove them from the wrapper, mimicking browsers' behaviour better.
+                const wrapperStyles = {
+                    ...(tagsStyles[tagName] || {}),
+                    ...(_getElementClassStyles(attribs, classesStyles)),
+                    ...cssStringToObject(attribs.style || '')
+                };
 
-                    let textChildrenInheritedStyles = {};
-                    Object.keys(wrapperStyles).forEach((styleKey) => {
-                        // Extract text-only styles
-                        if (TextOnlyPropTypes.indexOf(styleKey) !== -1) {
-                            textChildrenInheritedStyles[styleKey] = wrapperStyles[styleKey];
-                            delete wrapperStyles[styleKey];
-                        }
-                    });
-                    if (Object.keys(textChildrenInheritedStyles).length === 0) {
-                        // No style to apply to text children, avoid unecessary loops
-                        return parsedNode;
+                let textChildrenInheritedStyles = {};
+                Object.keys(wrapperStyles).forEach((styleKey) => {
+                    // Extract text-only styles
+                    if (TextOnlyPropTypes.indexOf(styleKey) !== -1) {
+                        textChildrenInheritedStyles[styleKey] = wrapperStyles[styleKey];
+                        delete wrapperStyles[styleKey];
                     }
-                    // Re-write wrapper's styles as a string
-                    parsedNode.attribs.style = cssObjectToString(wrapperStyles);
-                    for (let i = 0; i < children.length; i++) {
-                        const child = children[i];
-                        const { wrapper, attribs } = child;
+                });
+                if (Object.keys(textChildrenInheritedStyles).length === 0) {
+                    // No style to apply to text children, avoid unecessary loops
+                    return parsedNode;
+                }
+                // Re-write wrapper's styles as a string
+                parsedNode.attribs.style = cssObjectToString(wrapperStyles);
+                for (let i = 0; i < children.length; i++) {
+                    const child = children[i];
+                    const { wrapper, attribs } = child;
 
-                        if (wrapper === 'Text') {
-                            // Set (or merge) the inherited text styles extracted from the wrapper for
-                            // each Text child
-                            if (!attribs.style) {
-                                child.attribs.style = cssObjectToString(textChildrenInheritedStyles);
-                            } else {
-                                child.attribs.style = cssObjectToString({
-                                    ...textChildrenInheritedStyles,
-                                    ...cssStringToObject(child.attribs.style)
-                                });
-                            }
+                    if (wrapper === 'Text') {
+                        // Set (or merge) the inherited text styles extracted from the wrapper for
+                        // each Text child
+                        if (!attribs.style) {
+                            child.attribs.style = cssObjectToString(textChildrenInheritedStyles);
+                        } else {
+                            child.attribs.style = cssObjectToString({
+                                ...textChildrenInheritedStyles,
+                                ...cssStringToObject(child.attribs.style)
+                            });
                         }
                     }
                 }
-                return parsedNode;
-            });
+            }
+            return parsedNode;
+        });
         return this.associateRawTexts(RNElements);
     }
 
@@ -443,21 +443,21 @@ export default class HTML extends PureComponent {
             const classStyles = _getElementClassStyles(attribs, classesStyles);
             const textElement = data ?
                 <Text
-                    style={computeTextStyles(
-                        element,
-                        {
-                            defaultTextStyles: this.defaultTextStyles,
-                            tagsStyles,
-                            classesStyles,
-                            baseFontStyle,
-                            emSize,
-                            ptSize,
-                            ignoredStyles,
-                            allowedStyles
-                        })}
-                    {...textWrapperProps}
+                  style={computeTextStyles(
+                      element,
+                      {
+                          defaultTextStyles: this.defaultTextStyles,
+                          tagsStyles,
+                          classesStyles,
+                          baseFontStyle,
+                          emSize,
+                          ptSize,
+                          ignoredStyles,
+                          allowedStyles
+                      })}
+                    { ...textWrapperProps }
                 >
-                    {data}
+                    { data }
                 </Text> :
                 false;
 
@@ -467,11 +467,11 @@ export default class HTML extends PureComponent {
                 classStyles,
                 convertedCSSStyles
             ]
-                .filter((s) => s !== undefined);
+            .filter((s) => s !== undefined);
 
             const renderersProps = {};
             if (Wrapper === Text) {
-                Object.keys(textWrapperProps).map(propName => { renderersProps[propName] = textWrapperProps[propName] });
+                renderersProps = textWrapperProps;
             }
             return (
                 <Wrapper key={key} style={style} {...renderersProps}>
@@ -483,7 +483,7 @@ export default class HTML extends PureComponent {
     }
 
     render () {
-        const { customWrapper, remoteLoadingView, remoteErrorView, textWrapperProps } = this.props;
+        const { textWrapperProps, customWrapper, remoteLoadingView, remoteErrorView } = this.props;
         const { RNNodes, loadingRemoteURL, errorLoadingRemoteURL } = this.state;
         if (!RNNodes && !loadingRemoteURL && !errorLoadingRemoteURL) {
             return null;
@@ -500,7 +500,7 @@ export default class HTML extends PureComponent {
                 remoteErrorView(this.props, this.state) :
                 (
                     <View style={{ flex: 1, alignItems: 'center' }}>
-                        <Text style={{ fontStyle: 'italic', fontSize: 16 }} {...textWrapperProps}>Could not load {this.props.uri}</Text>
+                        <Text { ...textWrapperProps } style={{ fontStyle: 'italic', fontSize: 16 }}>Could not load { this.props.uri }</Text>
                     </View>
                 );
         }

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -66,7 +66,7 @@ export default class HTML extends PureComponent {
         textWrapperProps: {},
     }
 
-    constructor (props) {
+    constructor(props) {
         super(props);
         this.state = {};
         this.renderers = {
@@ -77,7 +77,7 @@ export default class HTML extends PureComponent {
         this.generateDefaultStyles(props.baseFontStyle);
     }
 
-    componentDidMount () {
+    componentDidMount() {
         this.registerDOM();
     }
 
@@ -98,7 +98,7 @@ export default class HTML extends PureComponent {
         }
     }
 
-    async registerDOM (props = this.props, cb) {
+    async registerDOM(props = this.props, cb) {
         const { html, uri } = props;
         if (html) {
             this.setState({ dom: html, loadingRemoteURL: false, errorLoadingRemoteURL: false });
@@ -123,7 +123,7 @@ export default class HTML extends PureComponent {
         }
     }
 
-    parseDOM (dom, props = this.props) {
+    parseDOM(dom, props = this.props) {
         const { decodeEntities, debug, onParsed } = this.props;
         const parser = new Parser(
             new DomHandler((_err, dom) => {
@@ -146,7 +146,7 @@ export default class HTML extends PureComponent {
         parser.done();
     }
 
-    generateDefaultStyles (baseFontStyle = this.props.baseFontStyle) {
+    generateDefaultStyles(baseFontStyle = this.props.baseFontStyle) {
         this.defaultBlockStyles = generateDefaultBlockStyles(baseFontStyle.fontSize || 14);
         this.defaultTextStyles = generateDefaultTextStyles(baseFontStyle.fontSize || 14);
     }
@@ -157,7 +157,7 @@ export default class HTML extends PureComponent {
      * @returns {boolean}
      * @memberof HTML
      */
-    childrenNeedAView (children) {
+    childrenNeedAView(children) {
         for (let i = 0; i < children.length; i++) {
             if (children[i].wrapper === 'View') {
                 // If we find at least one View, it has to be nested in one
@@ -168,7 +168,7 @@ export default class HTML extends PureComponent {
         return false;
     }
 
-    wrapperHasTextChild (children) {
+    wrapperHasTextChild(children) {
         for (let i = 0; i < children.length; i++) {
             if (children[i].wrapper === 'Text') {
                 return true;
@@ -185,7 +185,7 @@ export default class HTML extends PureComponent {
      * @returns {array}
      * @memberof HTML
      */
-    associateRawTexts (children) {
+    associateRawTexts(children) {
         for (let i = 0; i < children.length; i++) {
             const child = children[i];
             if (
@@ -233,7 +233,7 @@ export default class HTML extends PureComponent {
      * @returns
      * @memberof HTML
      */
-    mapDOMNodesTORNElements (DOMNodes, parentTag = false, props = this.props) {
+    mapDOMNodesTORNElements(DOMNodes, parentTag = false, props = this.props) {
         const { ignoreNodesFunction, ignoredTags, alterNode, alterData, alterChildren, tagsStyles, classesStyles } = props;
         let RNElements = DOMNodes.map((node, nodeIndex) => {
             let { children, data } = node;
@@ -384,7 +384,7 @@ export default class HTML extends PureComponent {
      * @returns {array}
      * @memberof HTML
      */
-    renderRNElements (RNElements, parentWrapper = 'root', parentIndex = 0, props = this.props) {
+    renderRNElements(RNElements, parentWrapper = 'root', parentIndex = 0, props = this.props) {
         const {
             allowedStyles,
             baseFontStyle,
@@ -475,8 +475,8 @@ export default class HTML extends PureComponent {
             }
             return (
                 <Wrapper key={key} style={style} {...renderersProps}>
-                    { textElement }
-                    { childElements }
+                    {textElement}
+                    {childElements}
                 </Wrapper>
             );
         }) : false;
@@ -507,7 +507,7 @@ export default class HTML extends PureComponent {
 
         return customWrapper ? customWrapper(RNNodes) : (
             <View style={this.props.containerStyle || {}}>
-                { RNNodes }
+                {RNNodes}
             </View>
         );
     }


### PR DESCRIPTION
***Warning! Breaking change***
Added `textProps` prop that replace existing `textSelectable` and `allowFontScaling`. Now, with this prop you are able to apply any text prop (`selectable`, `textBreakStrategy`, etc.) to text wrapper component.

Example usage:
```
                    <HTML
                        html={
                            newsItem.bodyHtml ||
                            '<div></div>'
                        }
                        imagesMaxWidth={maxWidth}
                        onLinkPress={onLinkPress}
                        tagsStyles={backendStyles.tagsStyles}
                        baseFontStyle={styles.text}
                        textProps={{ textBreakStrategy: "simple" }}
                    />
```