### PR TITLE
Make sure that not all whitespaces are removed

### DIFF
--- a/src/HTML.js
+++ b/src/HTML.js
@@ -261,7 +261,7 @@ export default class HTML extends PureComponent {
                 children = alteredChildren || children;
             }
             // Remove whitespaces to check if it's just a blank text
-            const strippedData = data && data.replace(/\s/g, '');
+            const strippedData = data && data.replace(/\s+/g, ' ');
             if (type === 'text') {
                 if (!strippedData || !strippedData.length) {
                     // This is blank, don't render an useless additional component


### PR DESCRIPTION
I couldn't find a reference to this, but if you have the following HTML it will not show the spacing correctly between the nodes:

```
Some <b>bold</b> text.
```

It will end up like visually like `Some boldtext.`

This fix will allow at least one space, adding an additional Text component, in favor of showing the layout correctly. 