### PR TITLE
[5.x] Add podspec for cocoapods installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "BSD-2-Clause",
   "repository": "https://github.com/archriss/react-native-render-html",
   "description": "React Native component that renders HTML as native views",
+  "homepage": "https://github.com/archriss/react-native-render-html",
   "keywords": [
     "react-native",
     "react-component",

--- a/react-native-render-html.podspec
+++ b/react-native-render-html.podspec
@@ -1,0 +1,20 @@
+
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/archriss/react-native-render-html.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
If you try to install this library with a project that uses cocoapods you will get the following error:

> [!] use_native_modules! skipped the react-native dependency 'react-native-render-html'. No podspec file was found.
    - Check to see if there is an updated version that contains the necessary podspec file
    - Contact the library maintainers or send them a PR to add a podspec. The react-native-webview podspec is a good example of a package.json driven
    podspec. See https://github.com/react-native-community/react-native-webview/blob/master/react-native-webview.podspec
    - If necessary, you can disable autolinking for the dependency and link it manually. See
    https://github.com/react-native-community/cli/blob/master/docs/autolinking.md#how-can-i-disable-autolinking-for-unsupported-library