### PR TITLE
feat/issues: reorganize issue management

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,22 +1,18 @@
+---
+name: Bug Report
+about: If you have found a bug, you should chose this template.
+title: ''
+labels: bug
+---
+
 <!--
   MAKE SURE TO READ AND FOLLOW THIS TEMPLATE CLOSELY OR YOUR ISSUE WILL BE CLOSED WITHOUT NOTICE
 -->
 
-### Is this a bug report or a feature request?
-
-(Write your answer here.)
-
 <!--
-  If you answered "Bug report":
-
-    We expect that it will take you about 30 minutes to produce a high-quality bug report.
-    While this may seem like a lot, putting care into issues helps us fix them faster.
-    For bug reports, it is REQUIRED to fill the rest of this template, or the issue will be closed.
-
-  If you answered "Feature request":
-
-    Make sure to describe as precisely as possible the feature you'd like to see implemented. When relevant, provide visual examples (screenshots, screencasts, diagrams...).
-    You can ignore the next steps as long as you've made sure that your description is as clear, thorough and illustrated as possible.
+  We expect that it will take you about 30 minutes to produce a high-quality bug report.
+  While this may seem like a lot, putting care into issues helps us fix them faster.
+  For bug reports, it is REQUIRED to fill the rest of this template, or the issue will be closed.
 -->
 
 ### Have you read [the guidelines](https://github.com/archriss/react-native-render-html/blob/master/CONTRIBUTING.md) regarding bug report?
@@ -35,7 +31,7 @@
 
 (Write your answer here and specify the iOS/Android versions on which you've been able to reproduce the issue.)
 
-### Is the bug reproductible in a production environment (not a debug one)?
+### Is the bug reproducible in a production environment (not a debug one)?
 
 (Write your answer here.)
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Stackoverflow 
+    url: https://stackoverflow.com/questions/tagged/react-native-render-html
+    about: Please request assistance here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request
+about: Describe a new feature for this library.
+title: ''
+labels: 'new feature'
+---
+
+<!--
+  MAKE SURE TO READ AND FOLLOW THIS TEMPLATE CLOSELY OR YOUR ISSUE WILL BE CLOSED WITHOUT NOTICE
+-->
+
+### Have you read [the documentation](https://github.com/archriss/react-native-render-html/blob/master/README.md) in its entirety?
+
+(Write your answer here.)
+
+### Have you made sure that your issue hasn't already been reported/solved?
+
+(Write your answer here.)
+
+### Feature
+
+<!--
+    Make sure to describe as precisely as possible the feature you'd like to see implemented. When relevant, provide visual examples (screenshots, screencasts, diagrams...).
+-->
+
+(Describe the feature here.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-render-html",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "author": "Archriss",
   "license": "BSD-2-Clause",
   "repository": "https://github.com/archriss/react-native-render-html",


### PR DESCRIPTION
@Exilz Summary of those changes:

- remove initial ISSUE_TEMPLATE.md
- create a hidden .github directory
- create [a config file](https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) to expose stackoverflow link in the template chooser
- create .github/ISSUE_TEMPLATE directory
- create two issue templates for bugs and feature requests