### PR TITLE
[5.x] Add html parser options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1994,6 +1994,21 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha512-cfBw6q6tT5sa1gSPFSRKzF/xxYrrmeiut7E0TxNBObiLSBTuFEHibcfEe3waQPEDbqBsq+ql/TOniw65EyDFMA==",
+      "dev": true
+    },
+    "@types/domutils": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@types/domutils/-/domutils-1.7.2.tgz",
+      "integrity": "sha512-Nnwy1Ztwq42SSNSZSh9EXBJGrOZPR+PQ2sRT4VZy8hnsFXfCil7YlKO2hd2360HyrtFz2qwnKQ13ENrgXNxJbw==",
+      "dev": true,
+      "requires": {
+        "@types/domhandler": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -2006,6 +2021,17 @@
       "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
       "dev": true,
       "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@types/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-fCxmHS4ryCUCfV9+CJZY1UjkbR+6Al/EQdX5Jh03qBj9gdlPG5q+7uNoDgE/ZNXb3XNWSAQgqKIWnbRCbOyyWA==",
+      "dev": true,
+      "requires": {
+        "@types/domhandler": "*",
+        "@types/domutils": "*",
         "@types/node": "*"
       }
     },
@@ -2861,6 +2887,16 @@
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
       "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bplist-creator": {
       "version": "0.0.8",
@@ -4614,6 +4650,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -7984,7 +8027,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "get-caller-file": {
           "version": "2.0.5",
@@ -8681,7 +8728,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "is-number": {
           "version": "3.0.0",
@@ -9282,6 +9333,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
     "@react-native-community/eslint-config": "^1.1.0",
+    "@types/htmlparser2": "^3.10.1",
     "@types/react": "^16.9.19",
     "@types/react-native": "^0.61.10",
     "babel-eslint": "10.1.0",

--- a/src/HTML.js
+++ b/src/HTML.js
@@ -22,7 +22,7 @@ export default class HTML extends PureComponent {
         ignoredTags: PropTypes.array.isRequired,
         ignoredStyles: PropTypes.array.isRequired,
         allowedStyles: PropTypes.array,
-        decodeEntities: PropTypes.bool.isRequired,
+        htmlParserOptions: PropTypes.object,
         debug: PropTypes.bool.isRequired,
         listsPrefixesRenderers: PropTypes.object,
         ignoreNodesFunction: PropTypes.func,
@@ -54,7 +54,7 @@ export default class HTML extends PureComponent {
     static defaultProps = {
         renderers: HTMLRenderers,
         debug: false,
-        decodeEntities: true,
+        htmlParserOptions: {},
         emSize: 14,
         ptSize: 1.3,
         staticContentMaxWidth: Dimensions.get('window').width,
@@ -140,7 +140,7 @@ export default class HTML extends PureComponent {
     }
 
     parseDOM (dom, props = this.props) {
-        const { decodeEntities, debug, onParsed } = this.props;
+        const { htmlParserOptions, debug, onParsed } = this.props;
         const parser = new Parser(
             new DomHandler((_err, dom) => {
                 let RNElements = this.mapDOMNodesTORNElements(dom, false, props);
@@ -156,7 +156,7 @@ export default class HTML extends PureComponent {
                     console.log('RNElements from render-html', RNElements);
                 }
             }),
-            { decodeEntities: decodeEntities }
+            { decodeEntities: true, ...htmlParserOptions }
         );
         parser.write(dom);
         parser.done();

--- a/types/react-native-render-html/index.d.ts
+++ b/types/react-native-render-html/index.d.ts
@@ -109,7 +109,7 @@ declare module "react-native-render-html" {
        * ParserOptions from [htmlparser2](https://github.com/fb55/htmlparser2/wiki/Parser-options)
        * Optional, defaults decodeEntities to true
        */
-      htmlParserOptions?: ParserOptions
+      htmlParserOptions?: ParserOptions;
       /**
        * Set a maximum width to non-responsive content (<iframe> for instance)
        */

--- a/types/react-native-render-html/index.d.ts
+++ b/types/react-native-render-html/index.d.ts
@@ -14,6 +14,7 @@ declare module "react-native-render-html" {
     TextStyle,
     ViewStyle
   } from "react-native";
+  import { ParserOptions } from "htmlparser2";
   namespace HTML {
     interface BaseNode {
       type: "text" | "tag";
@@ -105,10 +106,10 @@ declare module "react-native-render-html" {
        */
       uri?: string;
       /**
-       * Decode HTML entities of your content.
-       * Optional, defaults to true
+       * ParserOptions from [htmlparser2](https://github.com/fb55/htmlparser2/wiki/Parser-options)
+       * Optional, defaults decodeEntities to true
        */
-      decodeEntities?: boolean;
+      htmlParserOptions?: ParserOptions
       /**
        * Set a maximum width to non-responsive content (<iframe> for instance)
        */


### PR DESCRIPTION
<!--
  MAKE SURE TO READ AND FOLLOW THIS TEMPLATE CLOSELY OR YOUR PR WILL BE
  REJECTED WITHOUT NOTICE
-->

### Checks

- [x] I have read the contribution guidelines regarding Pull Requests here: https://git.io/JJ0Pg 

### Description
**Breaking Change**
Replaced `decodeEntities` with `htmlParserOptions` prop for more options control. You will now be able to specify more options like `lowerCaseAttributeNames`, `lowerCaseTags` etc which are available in the `htmlparser2` dependency library.

Some other parser library like https://github.com/remarkablemark/html-react-parser/blob/master/index.js, also does the same implementation.

A use case that I have encounter is when you are accessing the `htmlAttributes` in your custom renderer, all of the parsed attribute names are lower case by default. It would be a pain to pass them directly as our React component props since usually props are in camel case.

```
html:
<custom attributeName1="..." attributeName2="..." attributeName3="..."></custom>

renderer:
custom: (htmlAttribute, children) {
 // Previous behaviour, will have to assign the props one by one
 const { attributename1,  attributename2, attributename3 } = htmlAttribute

 // New behaviour, can spread them directly to our React component
 return (
  <CustomReactComponent {...htmlAttribute}>{children}</CustomReactComponent>
 )
}
```

